### PR TITLE
make lavadpu-runner init depend on lavapdu-listen

### DIFF
--- a/etc/lavapdu-runner.init
+++ b/etc/lavapdu-runner.init
@@ -1,7 +1,7 @@
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          lavapdu-runner
-# Required-Start:    $remote_fs $network postgresql
+# Required-Start:    $remote_fs $network postgresql lavapdu-listen
 # Required-Stop:     $remote_fs $network
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6


### PR DESCRIPTION
lavapdu-listen is responsible for creating the DB tables required by
listen and runner daemons. So runner needs to wait for listen on
startup to ensure DB has been created.