### PR TITLE
Speedup job processing

### DIFF
--- a/lavapdu/pdurunner.py
+++ b/lavapdu/pdurunner.py
@@ -50,6 +50,8 @@ class PDURunner(object):
                      request, port, hostname)
             self.do_job(hostname, port, request)
             self.dbh.delete_row(job_id)
+        else:
+            time.sleep(1)
 
     def driver_from_hostname(self, hostname):
         drivername = drivername_from_hostname(hostname, self.pdus)
@@ -81,4 +83,3 @@ class PDURunner(object):
             log.info("Starting a PDURunner for all PDUS")
         while 1:
             self.get_one()
-            time.sleep(2)


### PR DESCRIPTION
the runner polls postgres for new jobs which isn't great, but works.
However sleeping 2 seconds between every job is a bit problematic
especially when controlling pdus with lots of ports. Instead sleep for 1
second between polls only if no new jobs were available