### PR TITLE
systemd: Restart services on abnormal exit

### DIFF
--- a/etc/lavapdu-listen.service
+++ b/etc/lavapdu-listen.service
@@ -6,6 +6,7 @@ After=postgresql.service
 ExecStart=/usr/sbin/lavapdu-listen -j
 Type=forking
 PIDFile=/var/run/lavapdu-listen.pid
+Restart=on-abnormal
 
 [Install]
 WantedBy=network.target

--- a/etc/lavapdu-runner.service
+++ b/etc/lavapdu-runner.service
@@ -6,6 +6,7 @@ After=postgresql.service lavapdu-listen.service
 ExecStart=/usr/sbin/lavapdu-runner -j
 Type=forking
 PIDFile=/var/run/lavapdu-runner.pid
+Restart=on-abnormal
 
 [Install]
 WantedBy=network.target


### PR DESCRIPTION
I'm seeing occasional crashes of lavapdu-listen inside the postgres
python hooks. Unfortunately i don't have time to dig into it at the
moment, but configuring the systemd services to restart things on abnormal
exit is probably a good idea in any case ;).

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>