### PR TITLE
Drivers: Add support for Devantech USB relay drivers

### DIFF
--- a/lavapdu/drivers/devantechusb.py
+++ b/lavapdu/drivers/devantechusb.py
@@ -1,0 +1,81 @@
+#! /usr/bin/python
+
+#  Copyright 2017 Sjoerd Simons <sjoerd.simons@collabora.co.uk>
+#
+#  Based on PDUDriver:
+#     Copyright 2013 Linaro Limited
+#     Author Matt Hart <matthew.hart@linaro.org>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+
+import logging
+from lavapdu.drivers.driver import PDUDriver
+import serial
+
+log = logging.getLogger(__name__)
+
+
+class DevantechusbBase(PDUDriver):
+    connection = None
+    port_count = 0
+    supported = []
+
+    def __init__(self, hostname, settings):
+        self.hostname = hostname
+        log.debug(settings)
+        self.settings = settings
+        self.device = settings.get("device", "/dev/ttyACM0")
+        log.debug("device: %s" % self.device)
+
+        super(DevantechusbBase, self).__init__()
+
+    def port_interaction(self, command, port_number):
+        if port_number > self.port_count or port_number < 1:
+            err = "Port should be in the range 1 - %d" % (self.port_count)
+            log.error(err)
+            raise RuntimeError(err)
+
+        if command == "on":
+            byte = 0x64 + port_number
+        elif command == "off":
+            byte = 0x6e + port_number
+        else:
+            log.error("Unknown command %s." % (command))
+            return
+
+        s = serial.Serial(self.device, 9600)
+        s.write(chr(byte))
+        s.close()
+
+    @classmethod
+    def accepts(cls, drivername):
+        return drivername in cls.supported
+
+
+class DevantechUSB2(DevantechusbBase):
+    port_count = 2
+    supported = ["devantech_USB-RLY02",
+                 "devantech_USB-RLY82"]
+
+
+# Various 8 relay devices
+class DevantechUSB8(DevantechusbBase):
+    port_count = 8
+    supported = ["devantech_USB-RLY08B",
+                 "devantech_USB-RLY16",
+                 "devantech_USB-RLY16L",
+                 "devantech_USB-OPTO-RLY88",
+                 "devantech_USB-OPTO-RLY816"]

--- a/lavapdu/drivers/strategies.py
+++ b/lavapdu/drivers/strategies.py
@@ -35,6 +35,8 @@ from lavapdu.drivers.devantech import DevantechETH0621
 from lavapdu.drivers.devantech import DevantechETH484
 from lavapdu.drivers.devantech import DevantechETH008
 from lavapdu.drivers.devantech import DevantechETH8020
+from lavapdu.drivers.devantechusb import DevantechUSB2
+from lavapdu.drivers.devantechusb import DevantechUSB8
 from lavapdu.drivers.synaccess import SynNetBooter
 from lavapdu.drivers.egpms import EgPMS
 


### PR DESCRIPTION
Apart for network relay boards, Devantech also makes USB relay boards
(http://www.robot-electronics.co.uk/products/relay-modules/usb-relay.html).

Add support for these. This should support all current relays as they
all use the same basic serial commands for switching on relays 1 to 8.

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>