### PR TITLE
dbhandler: add some retries in case of DB problem

### DIFF
--- a/etc/lavapdu/lavapdu.conf
+++ b/etc/lavapdu/lavapdu.conf
@@ -6,6 +6,8 @@
         "dbuser": "pdudaemon",
         "dbpass": "pdudaemon",
         "dbname": "lavapdu",
+        "dbretry": 10,
+        "dbretryinterval": 60,
         "retries": 5,
         "logging_level": "INFO"
     },


### PR DESCRIPTION
This makes DBHandler far more robust in the case where it looses its connection
to the DB.

The retry configuration can be modified in the /etc/lavapdu/lavapdu.conf file,
using the "dbretry" and "dbretryinterval" keys. Default values are respectively
10 and 60 (in seconds) if the keys are not set.

Signed-off-by: Florent Jacquet <florent.jacquet@free-electrons.com>