### PR TITLE
Load the Runner in PDUDaemon.

### DIFF
--- a/pdudaemon/runnermaster.py
+++ b/pdudaemon/runnermaster.py
@@ -27,6 +27,7 @@ import sys
 import os
 import logging
 processes = []
+pdus = []
 log = logging.getLogger(__name__)
 
 
@@ -36,6 +37,7 @@ def start_runner(config, pdu):
     p.run_me()
 
 
+
 def start_em_up(config):
     pdus = pdus_from_config(config)
     for pdu in pdus:
@@ -43,6 +45,8 @@ def start_em_up(config):
         p.start()
         processes.append(p)
     signal.signal(signal.SIGTERM, signal_term_handler)
+
+def stop_runner():
     for proc in processes:
         proc.join()
 

--- a/pdudaemon/socketserver.py
+++ b/pdudaemon/socketserver.py
@@ -26,6 +26,8 @@ import sys
 import os
 from pdudaemon.dbhandler import DBHandler
 from pdudaemon.shared import drivername_from_hostname
+import pdudaemon.runnermaster as RunnerServer
+
 log = logging.getLogger(__name__)
 
 
@@ -50,7 +52,10 @@ class ListenerServer(object):
 
     def start(self):
         log.info("Starting the ListenerServer")
+        RunnerServer.start_em_up(self.config)
         self.server.serve_forever()
+        RunnerServer.stop_runner()
+
 
 
 class TCPRequestHandler(SocketServer.BaseRequestHandler):

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "daemon",
         "lockfile",
         "paramiko",
+        "requests",
         "pexpect",
         "psycopg2",
         "setproctitle"

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     description="Queueing daemon for PDUs",
     packages=find_packages(),
     install_requires=[
-        "daemon",
+        "python_daemon",
         "lockfile",
         "paramiko",
         "requests",


### PR DESCRIPTION
In the 0.0.6 Version, Runner Server is missing in PDUDaemon-start file. We can see so many queue items in database. If the Listener & Runner will be combined, the Runner should be called during start up. The first patch is working for this one.

What's more, I cannot setup pdudaemon in debian 9. The setup wanna find a package named daemon, I tried it, but failed. It should be python_daemon not daemon. 