### PR TITLE
Add PDU Runner into PDU Daemon

### DIFF
--- a/pdudaemon-start
+++ b/pdudaemon-start
@@ -19,6 +19,7 @@
 #  MA 02110-1301, USA.
 
 import logging
+import pdudaemon.runnermaster as RunnerServer
 from pdudaemon.shared import read_settings
 from pdudaemon.shared import get_common_argparser
 from pdudaemon.shared import setup_daemon
@@ -48,4 +49,5 @@ if __name__ == '__main__':
                      % (logfile,
                         settings['daemon']['hostname'],
                         settings['daemon']['port']))
+        RunnerServer.start_em_up(settings)
         ListenerServer(settings).start()

--- a/pdudaemon/runnermaster.py
+++ b/pdudaemon/runnermaster.py
@@ -43,8 +43,6 @@ def start_em_up(config):
         p.start()
         processes.append(p)
     signal.signal(signal.SIGTERM, signal_term_handler)
-    for proc in processes:
-        proc.join()
 
 def signal_term_handler(a, b):
     del a, b
@@ -52,4 +50,5 @@ def signal_term_handler(a, b):
     for proc in processes:
         log.debug("Terminate %s", proc.pid)
         proc.terminate()
+        proc.join()
     sys.exit(0)

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,11 @@ setup(
     description="Queueing daemon for PDUs",
     packages=find_packages(),
     install_requires=[
-        "daemon",
+        "python_daemon",
         "lockfile",
         "paramiko",
         "pexpect",
+        "requests",
         "psycopg2",
         "setproctitle"
     ],


### PR DESCRIPTION
In the 0.0.6 Version, Runner Server is missing in PDUDaemon-start file. We can see so many queue items in database. If the Listener & Runner will be combined, the Runner should be called during start up. 

What's more, pdudaemon cannot setup pdudaemon in debian 9. The setup wanna find a package named daemon. It should be python_daemon. Also, the requests package is required in drivers.