### PR TITLE
Add a HTTP listener

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include etc/pdudaemon/pdudaemon.conf
 include etc/pdudaemon.service
 include etc/pdudaemonlogrotate
+include pdudaemon-start

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ To be added.
 - **HTTP**
 The daemon can accept requests over plain HTTP. The port is configurable, but defaults to 16421
 There is no encryption or authentication, consider yourself warned.
-To enable, change the 'listener' setting in the 'daemon' section of the config file to 'http'. This will break 'pduclient' requests.
-An example request would be
+To enable, change the 'listener' setting in the 'daemon' section of the config file to 'http'. This will break 'pduclient' requests.  
+An example request would be  
 ``` curl http://pdudaemonhostname:16421/power/control/on?hostname=pdu01&port=1```
+
   ***Return Codes***
-    HTTP 200 - Request Accepted
-    HTTP 503 - Invalid Request, Request not accepted
+    - HTTP 200 - Request Accepted
+    - HTTP 503 - Invalid Request, Request not accepted
 
 - **pduclient**
 The bundled client is used when PDUDaemon is configured to listen to 'tcp' requests.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,15 @@ Debian packages are on the way, hopefully.
 To be added.
 ## Making a power control request
 - **HTTP**
-To be added
+The daemon can accept requests over plain HTTP. The port is configurable, but defaults to 16421
+There is no encryption or authentication, consider yourself warned.
+To enable, change the 'listener' setting in the 'daemon' section of the config file to 'http'. This will break 'pduclient' requests.
+An example request would be
+``` curl http://pdudaemonhostname:16421/power/control/on?hostname=pdu01&port=1```
+  ***Return Codes***
+    HTTP 200 - Request Accepted
+    HTTP 503 - Invalid Request, Request not accepted
+
 - **pduclient**
 The bundled client is used when PDUDaemon is configured to listen to 'tcp' requests.
 ```

--- a/etc/pdudaemon/pdudaemon.conf
+++ b/etc/pdudaemon/pdudaemon.conf
@@ -7,7 +7,8 @@
         "dbpass": "pdudaemon",
         "dbname": "pdudaemon",
         "retries": 5,
-        "logging_level": "INFO"
+        "logging_level": "INFO",
+        "listener": "tcp"
     },
     "pdus": {
         "test": {

--- a/pdudaemon-start
+++ b/pdudaemon-start
@@ -19,6 +19,8 @@
 #  MA 02110-1301, USA.
 
 import logging
+import sys
+import os
 import pdudaemon.runnermaster as RunnerServer
 from pdudaemon.shared import read_settings
 from pdudaemon.shared import get_common_argparser
@@ -26,6 +28,7 @@ from pdudaemon.shared import setup_daemon
 
 from pdudaemon.httpserver import PDUHTTPListener
 from pdudaemon.socketserver import ListenerServer
+from pdudaemon.dbhandler import DBHandler
 
 
 if __name__ == '__main__':
@@ -49,7 +52,10 @@ if __name__ == '__main__':
                         settings['daemon']['hostname'],
                         settings['daemon']['port']))
         if options.purge:
-            settings["purge"] = True
+            logging.info("Running a DB purge and exiting.")
+            temp_dbh = DBHandler(settings['daemon'])
+            temp_dbh.purge()
+            sys.exit(os.EX_OK)
         else:
             RunnerServer.start_em_up(settings)
         listener = settings['daemon'].get('listener', 'tcp')

--- a/pdudaemon-start
+++ b/pdudaemon-start
@@ -24,6 +24,7 @@ from pdudaemon.shared import read_settings
 from pdudaemon.shared import get_common_argparser
 from pdudaemon.shared import setup_daemon
 
+from pdudaemon.httpserver import PDUHTTPListener
 from pdudaemon.socketserver import ListenerServer
 
 
@@ -50,4 +51,8 @@ if __name__ == '__main__':
                         settings['daemon']['hostname'],
                         settings['daemon']['port']))
         RunnerServer.start_em_up(settings)
-        ListenerServer(settings).start()
+        listener = settings['daemon'].get('listener', 'tcp')
+        if listener == 'tcp':
+          ListenerServer(settings).start()
+        elif listener == 'http':
+          PDUHTTPListener(settings).start()

--- a/pdudaemon-start
+++ b/pdudaemon-start
@@ -41,8 +41,6 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     settings = read_settings(conffile)
-    if options.purge:
-        settings["purge"] = True
 
     context = setup_daemon(options, settings, pidfile)
     with context:
@@ -50,9 +48,12 @@ if __name__ == '__main__':
                      % (logfile,
                         settings['daemon']['hostname'],
                         settings['daemon']['port']))
-        RunnerServer.start_em_up(settings)
+        if options.purge:
+            settings["purge"] = True
+        else:
+            RunnerServer.start_em_up(settings)
         listener = settings['daemon'].get('listener', 'tcp')
         if listener == 'tcp':
-          ListenerServer(settings).start()
+            ListenerServer(settings).start()
         elif listener == 'http':
-          PDUHTTPListener(settings).start()
+            PDUHTTPListener(settings).start()

--- a/pdudaemon/dbhandler.py
+++ b/pdudaemon/dbhandler.py
@@ -61,7 +61,7 @@ class DBHandler(object):
 
     def insert_request(self, hostname, port, request, exectime):
         sql = "insert into pdu_queue (hostname,port,request,exectime) " \
-              "values ('%s',%i,'%s',%i)" % (hostname, port, request, exectime)
+              "values ('%s',%i,'%s',%i)" % (hostname, int(port), request, int(exectime))
         self.do_sql(sql)
 
     def delete_row(self, row_id):

--- a/pdudaemon/dbhandler.py
+++ b/pdudaemon/dbhandler.py
@@ -72,7 +72,7 @@ class DBHandler(object):
         return self.cursor.execute(sql)
 
     def purge(self):
-        log.debug("Purging all jobs from database")
+        log.info("Purging all jobs from database")
         self.do_sql("delete from pdu_queue")
         self.close()
 

--- a/pdudaemon/httpserver.py
+++ b/pdudaemon/httpserver.py
@@ -32,6 +32,7 @@ from pdudaemon.dbhandler import DBHandler
 from pdudaemon.shared import drivername_from_hostname
 log = logging.getLogger(__name__)
 
+
 class PDUHTTPHandler(BaseHTTPRequestHandler):
     def _set_headers(self, code):
         self.send_response(code)

--- a/pdudaemon/httpserver.py
+++ b/pdudaemon/httpserver.py
@@ -1,0 +1,107 @@
+#! /usr/bin/python
+
+#  Copyright 2018 Matt Hart <matt@mattface.org>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+
+
+try:
+    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+    import urlparse
+except ImportError:
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+    import urllib.parse as urlparse
+import logging
+import time
+import sys
+import os
+from pdudaemon.dbhandler import DBHandler
+from pdudaemon.shared import drivername_from_hostname
+log = logging.getLogger(__name__)
+
+class PDUHTTPHandler(BaseHTTPRequestHandler):
+    def _set_headers(self, code):
+        self.send_response(code)
+        self.send_header('Content-type', 'text/plain')
+        self.end_headers()
+
+    def do_GET(self):
+        logging.info("Handling HTTP request from %s: %s" % (self.client_address, self.path))
+        data = urlparse.parse_qs(urlparse.urlparse(self.path).query)
+        res = self.insert_request(data)
+        if res:
+            self._set_headers(200)
+            self.wfile.write("OK - accepted request\n")
+        else:
+            self._set_headers(500)
+            self.wfile.write("Invalid request\n")
+
+    def insert_request(self, data):
+        delay = 10
+        custom_delay = False
+        now = int(time.time())
+        if data.get('delay', None):
+            delay = data.get('delay')[0]
+            custom_delay = True
+        hostname = data.get('hostname', [None])[0]
+        port = data.get('port', [None])[0]
+        request = data.get('command', [None])[0]
+        if not hostname or not port or not request:
+            return False
+        drivername_from_hostname(hostname, self.server.config["pdus"])
+        dbh = self.server.dbh
+        if not (request in ["reboot", "on", "off"]):
+            log.info("Unknown request: %s", request)
+            return False
+        if request == "reboot":
+            log.debug("reboot requested, submitting off/on")
+            dbh.insert_request(hostname, port, "off", now)
+            dbh.insert_request(hostname, port, "on", now + int(delay))
+            return True
+        else:
+            if custom_delay:
+                log.debug("using delay as requested")
+                dbh.insert_request(hostname, port, request, now + delay)
+                return True
+            else:
+                dbh.insert_request(hostname, port, request, now)
+                return True
+
+
+class PDUHTTPListener(object):
+
+    def __init__(self, config):
+        self.config = config
+        settings = config["daemon"]
+        listen_host = settings["hostname"]
+        listen_port = settings["port"]
+        log.debug("PDUHTTPListener __init__")
+        if "purge" in config:
+            log.info("Running a DB purge and exiting.")
+            temp_dbh = DBHandler(settings)
+            temp_dbh.purge()
+            sys.exit(os.EX_OK)
+        log.info("listening on %s:%s", listen_host, listen_port)
+
+        self.server = HTTPServer((listen_host, listen_port), PDUHTTPHandler)
+        self.server.settings = settings
+        self.server.config = config
+        self.server.dbh = DBHandler(settings)
+        self.server.dbh.create_db()
+
+    def start(self):
+        log.info("Starting the HTTP server")
+        self.server.serve_forever()

--- a/pdudaemon/httpserver.py
+++ b/pdudaemon/httpserver.py
@@ -38,8 +38,11 @@ class PDUHTTPHandler(BaseHTTPRequestHandler):
         self.send_header('Content-type', 'text/plain')
         self.end_headers()
 
+    def log_message(self, format, *args):
+        pass
+
     def do_GET(self):
-        logging.info("Handling HTTP request from %s: %s" % (self.client_address, self.path))
+        log.info("Handling HTTP request from %s: %s" % (self.client_address, self.path))
         data = urlparse.parse_qs(urlparse.urlparse(self.path).query)
         res = self.insert_request(data)
         if res:

--- a/pdudaemon/socketserver.py
+++ b/pdudaemon/socketserver.py
@@ -37,11 +37,6 @@ class ListenerServer(object):
         listen_host = settings["hostname"]
         listen_port = settings["port"]
         log.debug("ListenerServer __init__")
-        if "purge" in config:
-            log.info("Running a DB purge and exiting.")
-            temp_dbh = DBHandler(settings)
-            temp_dbh.purge()
-            sys.exit(os.EX_OK)
         log.info("listening on %s:%s", listen_host, listen_port)
 
         self.server = TCPServer((listen_host, listen_port), TCPRequestHandler)

--- a/pdudaemon/socketserver.py
+++ b/pdudaemon/socketserver.py
@@ -38,7 +38,9 @@ class ListenerServer(object):
         listen_port = settings["port"]
         log.debug("ListenerServer __init__")
         if "purge" in config:
-            self.server.dbh.purge()
+            log.info("Running a DB purge and exiting.")
+            temp_dbh = DBHandler(settings)
+            temp_dbh.purge()
             sys.exit(os.EX_OK)
         log.info("listening on %s:%s", listen_host, listen_port)
 


### PR DESCRIPTION
Instead of having a dedicated client binary installed on every client
machine, offer a HTTP listener which accepts the same args as HTTP query
string values.
This way, client machines can use simple tools such as cURL to send
requests.