### PR TITLE
Use systemds own python bindings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pexpect
 requests
-systemd
+systemd_python
 paramiko
 pyserial
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     install_requires=[
         "requests",
         "pexpect",
-        "systemd",
+        "systemd_python",
         "paramiko",
         "pyserial"
     ],


### PR DESCRIPTION
Use the journal handler from the official systemd python bindings as
these are already available in Debian as opposed to the so-called
systemd from pypi.

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>