### PR TITLE
Add Ubiquiti mPower Pro (8 Port) support

### DIFF
--- a/pdudaemon/drivers/strategies.py
+++ b/pdudaemon/drivers/strategies.py
@@ -27,6 +27,7 @@ from pdudaemon.drivers.apc9210 import APC9210  # pylint: disable=W0611
 from pdudaemon.drivers.apc7921 import APC7921  # pylint: disable=W0611
 from pdudaemon.drivers.ubiquity import Ubiquity3Port  # pylint: disable=W0611
 from pdudaemon.drivers.ubiquity import Ubiquity6Port  # pylint: disable=W0611
+from pdudaemon.drivers.ubiquity import Ubiquity8Port  # pylint: disable=W0611
 from pdudaemon.drivers.localcmdline import LocalCmdline
 from pdudaemon.drivers.ip9258 import IP9258
 from pdudaemon.drivers.sainsmart import Sainsmart

--- a/pdudaemon/drivers/ubiquity.py
+++ b/pdudaemon/drivers/ubiquity.py
@@ -117,7 +117,7 @@ class Ubiquity6Port(UbiquityBase):
             return True
         return False
 
-""" Ubiquity mPower Pro """
+
 class Ubiquity8Port(UbiquityBase):
     port_count = 8
 
@@ -126,4 +126,3 @@ class Ubiquity8Port(UbiquityBase):
         if drivername == "ubntmfi8port":
             return True
         return False
-

--- a/pdudaemon/drivers/ubiquity.py
+++ b/pdudaemon/drivers/ubiquity.py
@@ -116,3 +116,14 @@ class Ubiquity6Port(UbiquityBase):
         if drivername == "ubntmfi6port":
             return True
         return False
+
+""" Ubiquity mPower Pro """
+class Ubiquity8Port(UbiquityBase):
+    port_count = 8
+
+    @classmethod
+    def accepts(cls, drivername):
+        if drivername == "ubntmfi8port":
+            return True
+        return False
+


### PR DESCRIPTION
Ubiquiti Networks mPower Pro 8-port switch (US) works the
same as the 3- and 6-port versions. The EU version of the
mPower Pro is 6-port.

Signed-off-by: Tim Orling <timothy.t.orling@linux.intel.com>