### PR TITLE
share/pdudaemon.service: use /usr/bin/pdudaemon

### DIFF
--- a/share/pdudaemon.service
+++ b/share/pdudaemon.service
@@ -2,7 +2,7 @@
 Description=Control and Queueing daemon for PDUs
 
 [Service]
-ExecStart=/usr/sbin/pdudaemon --journal --dbfile=/var/lib/pdudaemon/pdudaemon.db --conf=/etc/pdudaemon/pdudaemon.conf
+ExecStart=/usr/bin/pdudaemon --journal --dbfile=/var/lib/pdudaemon/pdudaemon.db --conf=/etc/pdudaemon/pdudaemon.conf
 Type=simple
 Restart=on-abnormal
 


### PR DESCRIPTION
By default, pdudaemon is installed in /usr/bin

Signed-off-by: Tim Orling <timothy.t.orling@linux.intel.com>