### PR TITLE
Add a docker file for automated building on dockerhub

### DIFF
--- a/share/Dockerfile.dockerhub
+++ b/share/Dockerfile.dockerhub
@@ -1,0 +1,22 @@
+FROM debian:stretch
+
+RUN apt-get update && apt-get install -y pep8 \
+python3-setuptools \
+python3-pip \
+libsystemd-dev \
+curl \
+psmisc \
+pkg-config \
+libffi-dev \
+libhidapi-dev \
+libudev-dev \
+libusb-1.0-0-dev \
+cython3 \
+supervisor
+
+ADD share/pdudaemon.conf /config/
+WORKDIR /pdudaemon
+COPY . .
+RUN pip3 install --user -r ./requirements.txt
+RUN python3 ./setup.py install
+CMD ["/usr/bin/supervisord", "-c", "/pdudaemon/share/supervisord.conf"]

--- a/share/supervisord.conf
+++ b/share/supervisord.conf
@@ -1,0 +1,11 @@
+[supervisord]
+nodaemon=true
+
+[program:pdudaemon]
+command=/usr/local/bin/pdudaemon --dbfile=/config/pdudaemon.db --conf=/config/pdudaemon.conf
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
Add a docker file that gets built with any changes by docker hub. Use supervisord to start the daemon and keep it running until the container is stopped.