### PR TITLE
Fix a race condition between the task queue and db queue

### DIFF
--- a/pdudaemon/pdurunner.py
+++ b/pdudaemon/pdurunner.py
@@ -29,12 +29,11 @@ import pdudaemon.drivers.strategies  # pylint: disable=W0611
 
 class PDURunner(threading.Thread):
 
-    def __init__(self, config, hostname, task_queue, db_queue, retries):
+    def __init__(self, config, hostname, task_queue, retries):
         super(PDURunner, self).__init__(name=hostname)
         self.config = config
         self.hostname = hostname
         self.task_queue = task_queue
-        self.db_queue = db_queue
         self.retries = retries
         self.logger = logging.getLogger("pdud.pdu.%s" % hostname)
         self.driver = self.driver_from_hostname(hostname)
@@ -71,5 +70,4 @@ class PDURunner(threading.Thread):
             self.logger.info("Processing task (%s %s)", request, port)
             self.do_job(port, request)
             self.task_queue.task_done()
-            self.db_queue.put(("DELETE", job_id))
         return 0


### PR DESCRIPTION
In some circumstances, the pdu task could take longer than the main loop takes to execute. As the pdurunner task is responsible for deleting the database row, the next database request would provide the same task.

Instead, after queueing the task, immediately delete the database row.

This also means the db_queue does not have to be passed to each pdurunner.