### PR TITLE
Dockerfile.dockerhub: Add telnet package

### DIFF
--- a/Dockerfile.dockerhub
+++ b/Dockerfile.dockerhub
@@ -12,6 +12,7 @@ libhidapi-dev \
 libudev-dev \
 libusb-1.0-0-dev \
 cython3 \
+telnet \
 supervisor
 
 ADD share/pdudaemon.conf /config/


### PR DESCRIPTION
Telnet is required by the synaccess, acmebase, and apcbase drivers.

Signed-off-by: Andy Doan <andy@foundries.io>