### PR TITLE
A few fixes before I integrate pdudaemon into Fuego

### DIFF
--- a/Dockerfile.dockerhub
+++ b/Dockerfile.dockerhub
@@ -14,7 +14,8 @@ python3-pip \
 python3-setuptools \
 python3-wheel \
 supervisor \
-telnet
+telnet \
+snmp
 
 ADD share/pdudaemon.conf /config/
 WORKDIR /pdudaemon

--- a/Dockerfile.dockerhub
+++ b/Dockerfile.dockerhub
@@ -1,5 +1,9 @@
 FROM debian:stretch
 
+ARG HTTP_PROXY
+ENV http_proxy ${HTTP_PROXY}
+ENV https_proxy ${HTTP_PROXY}
+
 RUN apt-get update && apt-get install -y \
 curl \
 cython3 \

--- a/Dockerfile.dockerhub
+++ b/Dockerfile.dockerhub
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 ARG HTTP_PROXY
 ENV http_proxy ${HTTP_PROXY}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,19 @@ APC, Devantech and ACME are well supported, however there is no official list ye
 ## Installing
 Debian packages are on the way, hopefully.
 For now, make sure the requirements are met and then:
+
 ```python3 setup.py install```
+
+Alternatively, you can install it on Docker:
+```
+$ git clone https://github.com/pdudaemon/pdudaemon
+$ cd pdudaemon
+$ vi share/pdudaemon.conf
+	- configure your PDUs
+$ sudo docker build -t pdudaemon --build-arg HTTP_PROXY=$http_proxy -f Dockerfile.dockerhub .
+$ docker run --rm -it -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e NO_PROXY="$no_proxy" --net="host" pdudaemon:latest
+```
+
 ## Config file
 To be added.
 ## Making a power control request

--- a/README.md
+++ b/README.md
@@ -17,11 +17,32 @@ To be added.
 - **HTTP**
 The daemon can accept requests over plain HTTP. The port is configurable, but defaults to 16421
 There is no encryption or authentication, consider yourself warned.
-To enable, change the 'listener' setting in the 'daemon' section of the config file to 'http'. This will break 'pduclient' requests.  
-An example request would be  
-``` curl http://pdudaemonhostname:16421/power/control/on?hostname=pdu01&port=1```
+To enable, change the 'listener' setting in the 'daemon' section of the config file to 'http'. This will break 'pduclient' requests.
+An HTTP request URL has the following syntax:
+
+  ```http://<pdudaemon-hostname>:<pdudaemon-port>/power/control/<command>?<query-string>```
+
+  Where:
+    - pdudaemon-hostname is the hostname or IP address where pdudaemon is running (e.g.: localhost)
+    - pdudaemon-port is the port used by pdudaemon (e.g.: 16421)
+    - command is an action for the PDU to execute:
+      - **on**: power on
+      - **off**: power off
+      - **reboot**: reboot
+    - query-string can have 3 parameters (same as pduclient, see below)
+      - **hostname**: the PDU hostname or IP address used in the [configuration file](https://github.com/pdudaemon/pdudaemon/blob/master/share/pdudaemon.conf) (e.g.: "192.168.10.2")
+      - **port**: the PDU port number
+      - **delay**: delay before a command runs (optional, by default 5 seconds)
+
+  Some example requests would be:
+  ```
+  $ curl "http://localhost:16421/power/control/on?hostname=192.168.10.2&port=1"
+  $ curl "http://localhost:16421/power/control/off?hostname=192.168.10.2&port=1"
+  $ curl "http://localhost:16421/power/control/reboot?hostname=192.168.10.2&port=1&delay=10"
+  ```
 
   ***Return Codes***
+
     - HTTP 200 - Request Accepted
     - HTTP 503 - Invalid Request, Request not accepted
 

--- a/share/Dockerfile.travis
+++ b/share/Dockerfile.travis
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 RUN apt-get update && apt-get install -y libsystemd-dev \
                                          curl \


### PR DESCRIPTION
- support for users that are behind a corporate web proxy
- upgrade Dockerfile to Debian buster because of python version problems
- improve the clarity of the Readme
- add temporarily snmp to the packages to install because the ip9258 driver needs snmpset. I will probably remove it later when I modify the driver to use the python library.