### PR TITLE
Add a direct drive feature

### DIFF
--- a/pdudaemon/__init__.py
+++ b/pdudaemon/__init__.py
@@ -149,7 +149,11 @@ def main():
             sys.exit(1)
         task_queue = Queue()
         runner = PDURunner(config, options.drivehostname, task_queue, options.driveretries)
-        result = runner.do_job(options.driveport, options.driverequest)
+        if options.driverequest == "reboot":
+            result = runner.do_job(options.driveport, "off")
+            result = runner.do_job(options.driveport, "on")
+        else:
+            result = runner.do_job(options.driveport, options.driverequest)
         # currently the drivers dont all reply with a result, so just exit(0) for now
         sys.exit(0)
 

--- a/pdudaemon/pdurunner.py
+++ b/pdudaemon/pdurunner.py
@@ -66,8 +66,8 @@ class PDURunner(threading.Thread):
                 self.logger.info("leaving")
                 self.task_queue.task_done()
                 return 0
-            job_id, port, request = job
+            port, request = job
             self.logger.info("Processing task (%s %s)", request, port)
-            self.do_job(port, request)
+            result = self.do_job(port, request)
             self.task_queue.task_done()
         return 0

--- a/share/expected_output.txt
+++ b/share/expected_output.txt
@@ -1,0 +1,4 @@
+1 off
+1 on
+drivetest 1 off
+drivetest 1 on

--- a/share/pdudaemon-test.sh
+++ b/share/pdudaemon-test.sh
@@ -1,17 +1,53 @@
 #!/bin/bash
-pdudaemon --loglevel=DEBUG --conf=share/pdudaemon.conf --dbfile=/tmp/dbfile &
-sleep 5
-curl -q "http://localhost:16421/power/control/reboot?hostname=test&port=1&delay=5" &> /dev/null
-sleep 15
-LINES=`cat /tmp/pdu | wc -l`
-if [[ $LINES -eq 2 ]]
+
+PDUD_BINARY=pdudaemon
+TMPFILE=/tmp/pdu
+
+while getopts l option
+do
+  case "${option}" in
+    l)
+      LOCAL=true
+      ;;
+  esac
+done
+
+#empty the tempfile, helpful if running locally
+if [ $LOCAL ]
 then
-  echo "localcmdline executed ok"
-  cat /tmp/pdu
-  exit 0
-else
-  echo "localcmdline test failed"
-  cat /tmp/pdu
-  exit 1
+  cp pdudaemon/__init__.py ./pdudaemon-test-bin
+  chmod +x ./pdudaemon-test-bin
+  PDUD_BINARY=./pdudaemon-test-bin
+  echo -n "" > $TMPFILE
 fi
 
+$PDUD_BINARY --loglevel=DEBUG --conf=share/pdudaemon.conf --dbfile=/tmp/dbfile &
+PDU_PID=$!
+
+sleep 2
+curl -q "http://localhost:16421/power/control/reboot?hostname=test&port=1&delay=5" &> /dev/null
+sleep 10
+
+if [ $LOCAL ]
+then
+  # kill the running daemon after first test, helpful if running locally
+  kill $PDU_PID
+  sleep 5
+fi
+
+$PDUD_BINARY --loglevel=DEBUG --conf=share/pdudaemon.conf --drive --hostname drivetest --port 1 --request reboot
+
+if [ $LOCAL ]
+then
+  rm $PDUD_BINARY
+fi
+
+echo "#### Created output ####"
+cat $TMPFILE
+echo ""
+echo "#### Expected output ####"
+cat share/expected_output.txt
+echo ""
+
+diff -q -u share/expected_output.txt $TMPFILE
+exit $?

--- a/share/pdudaemon.conf
+++ b/share/pdudaemon.conf
@@ -12,6 +12,11 @@
             "cmd_on": "echo '%d on' >> /tmp/pdu",
             "cmd_off": "echo '%d off' >> /tmp/pdu"
         },
+        "drivetest": {
+            "driver": "localcmdline",
+            "cmd_on": "echo 'drivetest %d on' >> /tmp/pdu",
+            "cmd_off": "echo 'drivetest %d off' >> /tmp/pdu"
+        },
         "baylibre-acme.local": {
             "driver": "acme"
         },


### PR DESCRIPTION
If a user doesnt require the queueing features of pdudaemon, but wants to still use the drivers, they can now use --drive with a few other commands to drive a PDU directly.