### PR TITLE
Support for EnerGenie USB PDU

### DIFF
--- a/Dockerfile.dockerhub
+++ b/Dockerfile.dockerhub
@@ -16,6 +16,7 @@ pkg-config \
 psmisc \
 python3-pip \
 python3-setuptools \
+python3-usb \
 python3-wheel \
 supervisor \
 telnet \

--- a/pdudaemon/drivers/energenieusb.py
+++ b/pdudaemon/drivers/energenieusb.py
@@ -1,0 +1,150 @@
+#!/usr/bin/python3
+
+#  Copyright 2019 Martyn Welch <martyn.welch@collabora.com>
+#
+#  Based on devantechusb:
+#     Copyright 2017 Sjoerd Simons
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+
+import logging
+from pdudaemon.drivers.driver import PDUDriver
+import usb.core
+import usb.util
+
+import os
+log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
+
+
+class EnerGenieUSB(PDUDriver):
+    supported = ["EG-PMS",
+                 "EG-PM2"]
+
+    def __init__(self, hostname, settings):
+        self.hostname = hostname
+        self.settings = settings
+        self.device = settings.get("device", "")
+        log.debug("device: %s" % self.device)
+
+    def port_interaction(self, command, port_number):
+
+        devices = self.connect()
+
+        if len(devices) == 0:
+            err = "No device found"
+            log.error(err)
+            raise RuntimeError(err)
+
+        dev = None
+        for d in devices:
+            if self.getid(d) == self.device:
+                dev = d
+                break
+        if dev is None:
+            err = "Device with id {} not found".format(self.device)
+            log.error(err)
+            raise RuntimeError(err)
+
+        if port_number > 4 or port_number < 1:
+            err = "Port should be in the range 1 - 4"
+            log.error(err)
+            raise RuntimeError(err)
+
+        if command == "on":
+            self.switchon(dev, port_number)
+        elif command == "off":
+            self.switchoff(dev, port_number)
+        else:
+            log.error("Unknown command %s." % (command))
+            return
+
+    @classmethod
+    def accepts(cls, drivername):
+        return drivername in cls.supported
+
+    # Following (modified) routines taken from pysispm:
+    #
+    # Copyright (c) 2016, Heinrich Schuchardt <xypron.glpk@gmx.de>
+    # All rights reserved.
+    #
+    # Redistribution and use in source and binary forms, with or without
+    # modification, are permitted provided that the following conditions are met:
+    #
+    #     * Redistributions of source code must retain the above copyright
+    #       notice, this list of conditions and the following disclaimer.
+    #
+    #     * Redistributions in binary form must reproduce the above copyright
+    #       notice, this list of conditions and the following disclaimer in the
+    #       documentation and/or other materials provided with the distribution.
+    #
+    # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    # ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+    # DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    # (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    # LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    # ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+    def connect(self):
+        """
+        Returns the list of compatible devices.
+        @return: device list
+        """
+        ret = list()
+        ret += list(usb.core.find(find_all=True, idVendor=0x04b4, idProduct=0xfd10))
+        ret += list(usb.core.find(find_all=True, idVendor=0x04b4, idProduct=0xfd11))
+        ret += list(usb.core.find(find_all=True, idVendor=0x04b4, idProduct=0xfd12))
+        ret += list(usb.core.find(find_all=True, idVendor=0x04b4, idProduct=0xfd13))
+        ret += list(usb.core.find(find_all=True, idVendor=0x04b4, idProduct=0xfd15))
+        return ret
+
+    def getid(self, dev):
+        """
+        Gets the id of a device.
+        @return: id
+        """
+        buf = bytes([0x00, 0x00, 0x00, 0x00, 0x00])
+        id = dev.ctrl_transfer(0xa1, 0x01, 0x0301, 0, buf, 500)
+        if (len(id) == 0):
+            return None
+        ret = ''
+        sep = ''
+        for x in id:
+            ret += sep
+            ret += format(x, '02x')
+            sep = ':'
+        return ret
+
+    def switchoff(self, dev, i):
+        """
+        Switches outlet i of the device off.
+        @param dev: device
+        @param i: outlet
+        """
+        buf = bytes([3 * i, 0x00, 0x00, 0x00, 0x00])
+        buf = dev.ctrl_transfer(0x21, 0x09, 0x0300 + 3 * i, 0, buf, 500)
+
+    def switchon(self, dev, i):
+        """
+        Switches outlet i of the device on.
+        @param dev: device
+        @param i: outlet
+        """
+        buf = bytes([3 * i, 0x03, 0x00, 0x00, 0x00])
+        buf = dev.ctrl_transfer(0x21, 0x09, 0x0300 + 3 * i, 0, buf, 500)

--- a/pdudaemon/drivers/strategies.py
+++ b/pdudaemon/drivers/strategies.py
@@ -43,3 +43,4 @@ from pdudaemon.drivers.egpms import EgPMS
 from pdudaemon.drivers.ykush import YkushXS
 from pdudaemon.drivers.ykush import Ykush
 from pdudaemon.drivers.snmp import SNMP
+from pdudaemon.drivers.energenieusb import EnerGenieUSB

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ setuptools
 hidapi
 pysnmp
 pyasn1
+pyusb

--- a/share/80-energenieusb.rules
+++ b/share/80-energenieusb.rules
@@ -1,0 +1,5 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="04b4", ATTR{idProduct}=="fd10", GROUP="pdudaemon", MODE="660"
+SUBSYSTEM=="usb", ATTR{idVendor}=="04b4", ATTR{idProduct}=="fd11", GROUP="pdudaemon", MODE="660"
+SUBSYSTEM=="usb", ATTR{idVendor}=="04b4", ATTR{idProduct}=="fd12", GROUP="pdudaemon", MODE="660"
+SUBSYSTEM=="usb", ATTR{idVendor}=="04b4", ATTR{idProduct}=="fd13", GROUP="pdudaemon", MODE="660"
+SUBSYSTEM=="usb", ATTR{idVendor}=="04b4", ATTR{idProduct}=="fd15", GROUP="pdudaemon", MODE="660"

--- a/share/find-energenie-serial.py
+++ b/share/find-energenie-serial.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+
+# It turns out that the device ID of the EnerGenie devices isn't the same
+# as the serial number printed on the unit. This script will return the
+# IDs of the devices found connected. The ID needs to be used in the
+# "device" field when configuring pdudaemon.conf to use an energenie PDU.
+
+import usb.core
+
+dev = list()
+dev += list(usb.core.find(find_all=True, idVendor=0x04b4, idProduct=0xfd10))
+dev += list(usb.core.find(find_all=True, idVendor=0x04b4, idProduct=0xfd11))
+dev += list(usb.core.find(find_all=True, idVendor=0x04b4, idProduct=0xfd12))
+dev += list(usb.core.find(find_all=True, idVendor=0x04b4, idProduct=0xfd13))
+dev += list(usb.core.find(find_all=True, idVendor=0x04b4, idProduct=0xfd15))
+
+for d in dev:
+    buf = bytes([0x00, 0x00, 0x00, 0x00, 0x00])
+    ret = d.ctrl_transfer(0xa1, 0x01, 0x0301, 0, buf, 500)
+    id = ":".join(format(x, '02x') for x in ret.tolist())
+    print(id)

--- a/share/pdudaemon.conf
+++ b/share/pdudaemon.conf
@@ -63,6 +63,10 @@
             "onsetting": "1",
             "offsetting": 2
         },
+        "energenie": {
+            "driver": "EG-PMS",
+            "device": "aa:bb:cc:xx:yy"
+        },
         "127.0.0.1": {
             "driver": "localcmdline"
         }


### PR DESCRIPTION
This series add support for the EnerGenie USB PDU, also sold by GemBird. A script is also included to enumerate connected devices as it turns out the device ID isn't the same as the serial number of the unit.