### PR TITLE
Add aliases support

### DIFF
--- a/pdudaemon/listener.py
+++ b/pdudaemon/listener.py
@@ -1,0 +1,104 @@
+#!/usr/bin/python3
+
+#  Copyright 2019 Matt Hart <matt@mattface.org>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+
+import logging
+import time
+logger = logging.getLogger('pdud.listener')
+
+
+class Args(object):
+    hostname = None
+    alias = None
+    request = None
+    port = None
+    pass
+
+
+def parse_tcp(data):
+    args = Args()
+    delay = None
+    array = data.split(" ")
+    now = int(time.time())
+    if (len(array) < 3) or (len(array) > 4):
+        logger.info("Wrong data size")
+        raise Exception("Unexpected data")
+    if len(array) == 4:
+        delay = int(array[3])
+    args.hostname = array[0]
+    args.port = int(array[1])
+    args.request = array[2]
+    args.delay = delay
+    return args
+
+
+def parse_http(data, path):
+    args = Args()
+    delay = None
+    entry = path.lstrip('/').split('/')
+    if len(entry) != 3:
+        logger.info("Request path was invalid: %s", entry)
+        return False
+    if not (entry[0] == 'power' and entry[1] == 'control'):
+        logger.info("Unknown request, path was %s", path)
+        return False
+    # everything comes back from the http library in a 1 sized list
+    args.alias = data.get('alias', [None])[0]
+    args.hostname = data.get('hostname', [None])[0]
+    args.port = data.get('port', [None])[0]
+    args.request = entry[2]
+    args.delay = data.get('delay', [None])[0]
+    return args
+
+
+def process_request(args, config, db_queue):
+    if args.delay:
+        logger.debug("using custom delay as requested")
+    else:
+        # this has been a default since the start, it should be smaller but I
+        # can't really change expected behaviour now
+        args.delay = 5
+    if args.alias:
+        if args.hostname or args.port:
+            logging.error("Trying to use and alias and also a hostname/port")
+            return False
+        # Using alias support, get all pdu info from alias
+        alias_settings = (config.get('aliases', {})).get(args.alias, False)
+        if not alias_settings:
+            logging.error("Alias requested but not found")
+            return False
+        args.hostname = config["aliases"][args.alias]["hostname"]
+        args.port = config["aliases"][args.alias]["port"]
+    if not args.hostname or not args.port or not args.request:
+        logger.info("One of hostname,port,request was not set")
+        return False
+    if args.hostname not in config['pdus']:
+        logger.info("PDU was not found in config")
+        return False
+    if not (args.request in ["reboot", "on", "off"]):
+        logger.info("Unknown request: %s", args.request)
+        return False
+    now = time.time()
+    if args.request == "reboot":
+        logger.debug("reboot requested, submitting off/on")
+        db_queue.put(("CREATE", args.hostname, args.port, "off", now))
+        db_queue.put(("CREATE", args.hostname, args.port, "on", now + int(args.delay)))
+        return True
+    else:
+        db_queue.put(("CREATE", args.hostname, args.port, args.request, now + int(args.delay)))
+        return True

--- a/share/expected_output.txt
+++ b/share/expected_output.txt
@@ -1,4 +1,10 @@
-1 off
-1 on
-drivetest 1 off
-drivetest 1 on
+http 2 off
+http 2 on
+httpalias 1 off
+httpalias 1 on
+tcp 3 off
+tcp 3 on
+drive 4 off
+drive 4 on
+drivealias 2 off
+drivealias 2 on

--- a/share/pdudaemon.conf
+++ b/share/pdudaemon.conf
@@ -12,10 +12,30 @@
             "cmd_on": "echo '%d on' >> /tmp/pdu",
             "cmd_off": "echo '%d off' >> /tmp/pdu"
         },
-        "drivetest": {
+        "drive": {
             "driver": "localcmdline",
-            "cmd_on": "echo 'drivetest %d on' >> /tmp/pdu",
-            "cmd_off": "echo 'drivetest %d off' >> /tmp/pdu"
+            "cmd_on": "echo 'drive %d on' >> /tmp/pdu",
+            "cmd_off": "echo 'drive %d off' >> /tmp/pdu"
+        },
+        "drivealias": {
+            "driver": "localcmdline",
+            "cmd_on": "echo 'drivealias %d on' >> /tmp/pdu",
+            "cmd_off": "echo 'drivealias %d off' >> /tmp/pdu"
+        },
+        "http": {
+            "driver": "localcmdline",
+            "cmd_on": "echo 'http %d on' >> /tmp/pdu",
+            "cmd_off": "echo 'http %d off' >> /tmp/pdu"
+        },
+        "httpalias": {
+            "driver": "localcmdline",
+            "cmd_on": "echo 'httpalias %d on' >> /tmp/pdu",
+            "cmd_off": "echo 'httpalias %d off' >> /tmp/pdu"
+        },
+        "tcp": {
+            "driver": "localcmdline",
+            "cmd_on": "echo 'tcp %d on' >> /tmp/pdu",
+            "cmd_off": "echo 'tcp %d off' >> /tmp/pdu"
         },
         "baylibre-acme.local": {
             "driver": "acme"
@@ -74,6 +94,16 @@
         },
         "127.0.0.1": {
             "driver": "localcmdline"
+        }
+    },
+    "aliases": {
+        "aliastesthttp01": {
+            "hostname": "httpalias",
+            "port": 1
+        },
+        "aliastestdrive02": {
+            "hostname": "drivealias",
+            "port": 2
         }
     }
 }


### PR DESCRIPTION
Aliases support allows device names to be set in the config file which map to a PDU hostname/port.

For automation services such as LAVA, these aliases can match the device name to make pdudeamon calls shorter, and device configuration easier to maintain. Alias also allow CI systems to outsource the power control configuration into pdudaemon, and only need to use the alias for all calls.

Also in this patch, improve the testing scripts to test the HTTP and TCP clients/listeners, and extract a lot of the shared listener code in a separate module so all listeners parse the requests with the same code.

Aliases are not supported when using the TCP listener/client, sorry.