### PR TITLE
Apply delay parameter only to reboot command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ An HTTP request URL has the following syntax:
     - query-string can have 3 parameters (same as pduclient, see below)
       - **hostname**: the PDU hostname or IP address used in the [configuration file](https://github.com/pdudaemon/pdudaemon/blob/master/share/pdudaemon.conf) (e.g.: "192.168.10.2")
       - **port**: the PDU port number
-      - **delay**: delay before a command runs (optional, by default 5 seconds)
+      - **delay**: delay between power off and on during reboot (optional, by default 5 seconds)
 
   Some example requests would be:
   ```

--- a/pdudaemon/listener.py
+++ b/pdudaemon/listener.py
@@ -100,5 +100,5 @@ def process_request(args, config, db_queue):
         db_queue.put(("CREATE", args.hostname, args.port, "on", now + int(args.delay)))
         return True
     else:
-        db_queue.put(("CREATE", args.hostname, args.port, args.request, now + int(args.delay)))
+        db_queue.put(("CREATE", args.hostname, args.port, args.request, now))
         return True

--- a/pdudaemon/listener.py
+++ b/pdudaemon/listener.py
@@ -67,12 +67,17 @@ def parse_http(data, path):
 
 
 def process_request(args, config, db_queue):
-    if args.delay:
+    if args.request in ["on", "off"] and args.delay is not None:
+        logger.warn("delay parameter is deprecated for on/off commands")
+    if args.delay is not None:
         logger.debug("using custom delay as requested")
     else:
         # this has been a default since the start, it should be smaller but I
         # can't really change expected behaviour now
-        args.delay = 5
+        if args.request == "reboot":
+            args.delay = 5
+        else:
+            args.delay = 0
     if args.alias:
         if args.hostname or args.port:
             logging.error("Trying to use and alias and also a hostname/port")
@@ -100,5 +105,5 @@ def process_request(args, config, db_queue):
         db_queue.put(("CREATE", args.hostname, args.port, "on", now + int(args.delay)))
         return True
     else:
-        db_queue.put(("CREATE", args.hostname, args.port, args.request, now))
+        db_queue.put(("CREATE", args.hostname, args.port, args.request, now + int(args.delay)))
         return True


### PR DESCRIPTION
Unlike putting a delay in between the reboot command, delaying a on/off
command before execution is not very intuitive; so remove it. See also
issue #72.