### PR TITLE
drivers: devantechusb: Use serial_for_url

### DIFF
--- a/pdudaemon/drivers/devantechusb.py
+++ b/pdudaemon/drivers/devantechusb.py
@@ -56,7 +56,7 @@ class DevantechusbBase(PDUDriver):
             log.error("Unknown command %s." % (command))
             return
 
-        s = serial.Serial(self.device, 9600)
+        s = serial.serial_for_url(self.device, 9600)
         s.write([byte])
         s.close()
 


### PR DESCRIPTION
Using serial_for_url when opening devices still supports device="/dev/ttyACM0"
but also stuff like hwgrep://LOCATION=3-1\b in order to open by
usb path or serial number.

See https://pyserial.readthedocs.io/en/latest/url_handlers.html

Signed-off-by: Leonard Crestez <leonard.crestez@nxp.com>