### PR TITLE
pdudaemon: bcu: Init "remote control" every on/off

### DIFF
--- a/pdudaemon/drivers/bcu.py
+++ b/pdudaemon/drivers/bcu.py
@@ -57,9 +57,6 @@ class BCU(PDUDriver):
         #: bootmode to initialize (see `bcu lsbootmode -board=$board`)
         self.bootmode = settings.get('bootmode', None)
 
-        # Initialize "remote control mode" at startup and never release
-        self._init()
-
     def _run(self, subcmd):
         cmd = [self.bcu_exe]
         cmd += subcmd
@@ -77,11 +74,13 @@ class BCU(PDUDriver):
         return self._run(['set_gpio', gpio, value])
 
     def port_on(self, port_number):
+        self._init()
         self._set_gpio(
             self.reset_gpio,
             '1' if self.reset_gpio_active_low else '0')
 
     def port_off(self, port_number):
+        self._init()
         self._set_gpio(
             self.reset_gpio,
             '0' if self.reset_gpio_active_low else '1')


### PR DESCRIPTION
After adding a bcu-based board to a boardfarm it works initially but
eventually fails to reboot. It is not clear why settings are sometimes
lost but state is 'held' inside an i2c-to-gpio expander so it's better
to not rely on it.

This can be solved by manually running "bcu init" so fix by making
pdudaemon reinitialize "remote control" mode on every operation, similar
to what "bcu reset" does.

With this patch board reset is still available after a few days.

Signed-off-by: Leonard Crestez <leonard.crestez@nxp.com>