### PR TITLE
use asyncio/aiohttp and drop database/queueing

### DIFF
--- a/Dockerfile.dockerhub
+++ b/Dockerfile.dockerhub
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 
 ARG HTTP_PROXY
 ENV http_proxy ${HTTP_PROXY}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp
 pexpect
 requests
 systemd_python

--- a/share/pdudaemon-test.sh
+++ b/share/pdudaemon-test.sh
@@ -2,10 +2,8 @@
 
 PDUD_BINARY=pdudaemon
 TMPFILE=/tmp/pdu
-DBFILE=/tmp/dbfile
 
 rm $TMPFILE
-rm $DBFILE
 
 # support the -l option for running the tests locally
 while getopts l option
@@ -25,7 +23,7 @@ then
   PDUD_BINARY=./pdudaemon-test-bin
 fi
 
-$PDUD_BINARY --loglevel=DEBUG --conf=share/pdudaemon.conf --dbfile=$DBFILE &
+$PDUD_BINARY --loglevel=DEBUG --conf=share/pdudaemon.conf &
 PDU_PID=$!
 
 sleep 3
@@ -41,7 +39,7 @@ kill $PDU_PID
 sleep 10
 
 # Test TCP listener
-$PDUD_BINARY --loglevel=DEBUG --listener tcp --conf=share/pdudaemon.conf --dbfile=$DBFILE &
+$PDUD_BINARY --loglevel=DEBUG --listener tcp --conf=share/pdudaemon.conf &
 PDU_PID=$!
 
 sleep 3

--- a/share/pdudaemon.service
+++ b/share/pdudaemon.service
@@ -2,7 +2,7 @@
 Description=Control and Queueing daemon for PDUs
 
 [Service]
-ExecStart=/usr/sbin/pdudaemon --journal --dbfile=/var/lib/pdudaemon/pdudaemon.db --conf=/etc/pdudaemon/pdudaemon.conf
+ExecStart=/usr/sbin/pdudaemon --journal --conf=/etc/pdudaemon/pdudaemon.conf
 Type=simple
 DynamicUser=yes
 StateDirectory=pdudaemon

--- a/share/supervisord.conf
+++ b/share/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:pdudaemon]
-command=/usr/local/bin/pdudaemon --dbfile=/config/pdudaemon.db --conf=/config/pdudaemon.conf
+command=/usr/local/bin/pdudaemon --conf=/config/pdudaemon.conf
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
This is a quick hack to rip out worker threads and queuing via sqlite, replacing them with asyncio and aiohttpd. Each PDURunner now has an `asyncio.Lock` to serialize the `loop.run_in_executor` calls, which then run the actual driver code in a asyncio thread pool. This only implements blocking mode (see #75).

I've tried to keep the general structure close to the original code to make it easier to follow the changes. Only --drive mode and the http listener work right now, and I've only tested the `localcmdline` driver.

Further work:
- [ ] replace urlparse and listener.parse_http with the aiohttp mechanisms
- [x] port the tcp listener
- [x] clean up signal handling and shutdown

Possible future work:
- [ ] show available drivers in the `/` path
- [ ] print incremental feedback during request processing (waiting, retrying, ...)