### PR TITLE
Add APC AP7900 support

### DIFF
--- a/pdudaemon/drivers/apc7900.py
+++ b/pdudaemon/drivers/apc7900.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python3
+
+#  Copyright 2017 Matt Hart <matt@mattface.org>
+#  Copyright 2020 Nobuhiro Iwamatsu <iwamatsu@nigauri.org>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+
+import logging
+from pdudaemon.drivers.apc7952 import APC7952
+import os
+log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
+
+
+class APC7900(APC7952):
+
+    @classmethod
+    def accepts(cls, drivername):
+        if drivername == "apc7900":
+            return True
+        return False
+
+    def _port_interaction(self, command, port_number):
+        log.debug("Attempting command: %s port: %i",
+                  command, port_number)
+        # make sure in main menu here
+        self._back_to_main()
+        self.connection.send("\r")
+        self.connection.expect("1- Device Manager")
+        self.connection.expect("> ")
+        log.debug("Entering Device Manager")
+        self.connection.send("1\r")
+        self.connection.expect("------- Device Manager")
+        self.connection.send("3\r")
+        self.connection.expect("3- Outlet Control/Configuration")
+        self.connection.expect("> ")
+        self._enter_outlet(port_number, False)
+        self.connection.expect("1- Control Outlet")
+        self.connection.send("1\r")
+        self.connection.expect("> ")
+        if command == "on":
+            self.connection.send("1\r")
+            self.connection.expect("Immediate On")
+            self._do_it()
+        elif command == "off":
+            self.connection.send("2\r")
+            self.connection.expect("Immediate Off")
+            self._do_it()
+        else:
+            log.debug("Unknown command!")

--- a/pdudaemon/drivers/strategies.py
+++ b/pdudaemon/drivers/strategies.py
@@ -23,6 +23,7 @@ from pdudaemon.drivers.anelnetpwrctrl import AnelNETPwrCtrlHOME  # pylint: disab
 from pdudaemon.drivers.anelnetpwrctrl import AnelNETPwrCtrlADV  # pylint: disable=W0611
 from pdudaemon.drivers.anelnetpwrctrl import AnelNETPwrCtrlIO  # pylint: disable=W0611
 from pdudaemon.drivers.anelnetpwrctrl import AnelNETPwrCtrlPRO  # pylint: disable=W0611
+from pdudaemon.drivers.apc7900 import APC7900  # pylint: disable=W0611
 from pdudaemon.drivers.apc7932 import APC7932  # pylint: disable=W0611
 from pdudaemon.drivers.apc7952 import APC7952  # pylint: disable=W0611
 from pdudaemon.drivers.apc9218 import APC9218  # pylint: disable=W0611


### PR DESCRIPTION
This adds APC AP7900 support.
https://www.apc.com/shop/us/en/products/Rack-PDU-Switched-1U-15A-100-120V-8-5-15/P-AP7900

I tested with pdudaemon.conf following:
```
{
    "daemon": {
        "hostname": "0.0.0.0",
        "port": 16421,
        "dbname": "pdudaemon",
        "logging_level": "DEBUG",
        "listener": "http"
    },
    "pdus": {
        "192.168.0.14": {
            "driver": "apc7900"
        }
    }
}
```

Signed-off-by: Nobuhiro Iwamatsu <iwamatsu@nigauri.org>