### PR TITLE
implement support for the Devantech dS2824

### DIFF
--- a/pdudaemon/drivers/devantech.py
+++ b/pdudaemon/drivers/devantech.py
@@ -202,6 +202,7 @@ class DevantechDSBase(PDUDriver):
     def accepts(cls, drivername):
         return False
 
+
 class DevantechDS2824(DevantechDSBase):
     port_count = 8
 

--- a/pdudaemon/drivers/devantech.py
+++ b/pdudaemon/drivers/devantech.py
@@ -162,7 +162,8 @@ class DevantechDSBase(PDUDriver):
     def __init__(self, hostname, settings):
         self.hostname = hostname
         self.settings = settings
-        self.ip = settings.get("ip", "192.168.0.123")
+        # the default hostname may vary. I.e. could be "ds378" for other modules.
+        self.ip = settings.get("ip", "dS2824")
         self.port = settings.get("port", 17123)
         super().__init__()
 

--- a/pdudaemon/drivers/strategies.py
+++ b/pdudaemon/drivers/strategies.py
@@ -42,6 +42,7 @@ from pdudaemon.drivers.devantech import DevantechETH0621
 from pdudaemon.drivers.devantech import DevantechETH484
 from pdudaemon.drivers.devantech import DevantechETH008
 from pdudaemon.drivers.devantech import DevantechETH8020
+from pdudaemon.drivers.devantech import DevantechDS2824
 from pdudaemon.drivers.devantechusb import DevantechUSB2
 from pdudaemon.drivers.devantechusb import DevantechUSB8
 from pdudaemon.drivers.numatousb import NumatoUSB1


### PR DESCRIPTION
This implements the most simple TCP/IP based command interface (ascii)[0]
of the Devantech dS2824. Note, that the dS2824 appears to be compatible
with the dS378.

Other possible (not implemented) command interfaces are:
 - Binary
 - AES enctyped
 - Modbus

[0] https://www.robotshop.com/media/files/content/d/dev/pdf/ds2824_-_v4.03.pdf

Signed-off-by: Leif Middelschulte <leif.middelschulte@klsmartin.com>