### PR TITLE
Fix Tasmota HTTP response handling

### DIFF
--- a/pdudaemon/drivers/tasmota.py
+++ b/pdudaemon/drivers/tasmota.py
@@ -55,7 +55,8 @@ class TasmotaBase(PDUDriver):
 
         r.raise_for_status()
         res = r.json()
-        if res != {'POWER': command.upper()}:
+        if (res != {'POWER': command.upper()}
+                and res != {'POWER' + str(port_number): command.upper()}):
             log.error(res)
             raise FailedRequestException(res)
         log.debug('HTTP response: {}'.format(res))


### PR DESCRIPTION
Depending on the device/firmware, the response does contain the port number or not.