### PR TITLE
Fix Dockerfile build issues

### DIFF
--- a/Dockerfile.dockerhub
+++ b/Dockerfile.dockerhub
@@ -9,6 +9,7 @@ curl \
 cython3 \
 libffi-dev \
 libhidapi-dev \
+libssl-dev \
 libsystemd-dev \
 libudev-dev \
 libusb-1.0-0-dev \
@@ -18,6 +19,7 @@ python3-pip \
 python3-setuptools \
 python3-usb \
 python3-wheel \
+rustc \
 supervisor \
 telnet \
 snmp

--- a/share/Dockerfile.travis
+++ b/share/Dockerfile.travis
@@ -8,7 +8,9 @@ RUN apt-get update && apt-get install -y libsystemd-dev \
                                          libhidapi-dev \
                                          libudev-dev \
                                          libusb-1.0-0-dev \
-                                         cython3
+                                         libssl-dev \
+                                         cython3 \
+                                         rustc
 
 RUN apt-get install --no-install-recommends -y python3-pip python3-setuptools python3-wheel python3-pytest
 ADD requirements.txt /


### PR DESCRIPTION
A pip package apparently needed rustc and libssl-dev installed, so
add these to the dockerfiles to make travis tests run again.