### PR TITLE
Add config options for pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ before_install:
     - tar -c requirements.txt share/Dockerfile.travis | docker build -t pdudaemon -f share/Dockerfile.travis -
 
 script:
-    - docker run -v $(pwd):/p -w /p pdudaemon /root/.local/bin/pycodestyle --ignore=E501 .
+    - docker run -v $(pwd):/p -w /p pdudaemon /root/.local/bin/pycodestyle --config=pycodestyle_config .
     - docker run -v $(pwd):/p -w /p pdudaemon sh -c "pytest-3 ."
     - docker run -v $(pwd):/p -w /p pdudaemon sh -c "python3 ./setup.py install && ./share/pdudaemon-test.sh"

--- a/pycodestyle_config
+++ b/pycodestyle_config
@@ -1,0 +1,3 @@
+[pycodestyle]
+show-source = True
+ignore = E501,W503


### PR DESCRIPTION
Rather than hardcoding the pycodestyle config into the travis
CI yaml file, add a config file for pycodestyle and read that
instead.