### PR TITLE
TPLink: List confirmed devices

### DIFF
--- a/pdudaemon/drivers/tplink.py
+++ b/pdudaemon/drivers/tplink.py
@@ -17,6 +17,11 @@
 #  along with this program; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 #  MA 02110-1301, USA.
+#
+#  Confirmed devices
+#    - KP303: https://www.tp-link.com/uk/home-networking/smart-plug/kp303/
+#    - KP105: https://www.tp-link.com/uk/home-networking/smart-plug/kp105/
+#    - HS105: https://www.tp-link.com/us/home-networking/smart-plug/hs105/
 
 import logging
 import json


### PR DESCRIPTION
There are many types of TP-Link smart plugs, and I was able to confirm the
operation of my device (HS102).
This adds the confirmed smart plug device information to the driver
header of the file for the user.

Signed-off-by: Nobuhiro Iwamatsu <iwamatsu@nigauri.org>