### PR TITLE
Add support for cleware usb switch 4 and 8

### DIFF
--- a/pdudaemon/drivers/cleware.py
+++ b/pdudaemon/drivers/cleware.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python3
+
+#  Copyright 2022 Sjoerd Simons <sjoerd@collabora.com>
+#
+#  Based on PDUDriver:
+#     Copyright 2013 Linaro Limited
+#     Author Matt Hart <matthew.hart@linaro.org>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+
+import logging
+from pdudaemon.drivers.driver import PDUDriver
+import hid
+import os
+
+log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
+
+CLEWARE_VID = 0x0d50
+CLEWARE_SWITCH1_PID = 0x0008
+CLEWARE_CONTACT00_PID = 0x0030
+
+
+class ClewareSwitch1Base(PDUDriver):
+    connection = None
+    port_count = 0
+
+    def __init__(self, hostname, settings):
+        self.hostname = hostname
+        self.settings = settings
+        self.serial = settings.get("serial", u"")
+        log.debug("serial: %s" % self.serial)
+
+        super().__init__()
+
+    def port_interaction(self, command, port_number):
+        port_number = int(port_number)
+        if port_number > self.port_count or port_number < 1:
+            err = "Port should be in the range 1 - %d" % (self.port_count)
+            log.error(err)
+            raise RuntimeError(err)
+
+        port = 0x10 + port_number - 1
+        if command == "on":
+            on = 1
+        elif command == "off":
+            on = 0
+        else:
+            log.error("Unknown command %s." % (command))
+            return
+
+        d = hid.device()
+        d.open(CLEWARE_VID, CLEWARE_SWITCH1_PID, serial_number=self.serial)
+        d.write([0, 0, port, on])
+        d.close()
+
+    @classmethod
+    def accepts(cls, drivername):
+        return drivername.lower() == cls.__name__.lower()
+
+
+class ClewareUsbSwitch4(ClewareSwitch1Base):
+    port_count = 4
+
+
+class ClewareContact00Base(PDUDriver):
+    connection = None
+    port_count = 0
+
+    def __init__(self, hostname, settings):
+        self.hostname = hostname
+        self.settings = settings
+        self.serial = settings.get("serial", u"")
+        log.debug("serial: %s" % self.serial)
+
+        super().__init__()
+
+    def port_interaction(self, command, port_number):
+        port_number = int(port_number)
+        if port_number > self.port_count or port_number < 1:
+            err = "Port should be in the range 1 - %d" % (self.port_count)
+            log.error(err)
+            raise RuntimeError(err)
+
+        port = 1 << (port_number - 1)
+        if command == "on":
+            on = port
+        elif command == "off":
+            on = 0
+        else:
+            log.error("Unknown command %s." % (command))
+            return
+
+        d = hid.device()
+        d.open(CLEWARE_VID, CLEWARE_CONTACT0_PID, serial_number=self.serial)
+        d.write([0, 3, on >> 8, on & 0xff, port >> 8, port & 0xff])
+        d.close()
+
+    @classmethod
+    def accepts(cls, drivername):
+        return drivername.lower() == cls.__name__.lower()
+
+
+class ClewareUsbSwitch8(ClewareContact00Base):
+    port_count = 8

--- a/pdudaemon/drivers/strategies.py
+++ b/pdudaemon/drivers/strategies.py
@@ -31,6 +31,7 @@ from pdudaemon.drivers.apc8959 import APC8959  # pylint: disable=W0611
 from pdudaemon.drivers.apc9210 import APC9210  # pylint: disable=W0611
 from pdudaemon.drivers.apc7920 import APC7920  # pylint: disable=W0611
 from pdudaemon.drivers.apc7921 import APC7921  # pylint: disable=W0611
+from pdudaemon.drivers.cleware import ClewareUsbSwitch4
 from pdudaemon.drivers.ubiquity import Ubiquity3Port  # pylint: disable=W0611
 from pdudaemon.drivers.ubiquity import Ubiquity6Port  # pylint: disable=W0611
 from pdudaemon.drivers.ubiquity import Ubiquity8Port  # pylint: disable=W0611

--- a/share/80-cleware.rules
+++ b/share/80-cleware.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="0d50", ATTR{idProduct}=="0008", GROUP="pdudaemon", MODE="660"
+SUBSYSTEM=="usb", ATTR{idVendor}=="0d50", ATTR{idProduct}=="0030", GROUP="pdudaemon", MODE="660"

--- a/share/pdudaemon.conf
+++ b/share/pdudaemon.conf
@@ -88,6 +88,14 @@
             "onsetting": "1",
             "offsetting": 2
         },
+        "cleware-usb-switch-4": {
+          "driver": "ClewareUsbSwitch4",
+          "serial": "12345"
+        },
+        "cleware-usb-switch-8": {
+          "driver": "ClewareUsbSwitch8",
+          "serial": "54321"
+        },
         "intellinet163682": {
           "driver": "intellinet",
           "username": "admin",


### PR DESCRIPTION
Cleware usb switch 4 can switch 4 wall sockets, while the usb switch 8
supports 8 pin plugs instead. Both use different interfaces, which might
be re-used on different cleware devices hence the split into baseclasses

0: https://www.cleware-shop.de/epages/63698188.sf/en_GB/?ObjectPath=/Shops/63698188/Products/11/SubProducts/11-3
1: https://www.cleware-shop.de/USB-Switch-8-EN

Signed-off-by: Sjoerd Simons <sjoerd@collabora.com>