### PR TITLE
Fix Cleware driver's UsbSwitch8 PID variable usage

### DIFF
--- a/pdudaemon/drivers/cleware.py
+++ b/pdudaemon/drivers/cleware.py
@@ -104,7 +104,7 @@ class ClewareContact00Base(PDUDriver):
             return
 
         d = hid.device()
-        d.open(CLEWARE_VID, CLEWARE_CONTACT0_PID, serial_number=self.serial)
+        d.open(CLEWARE_VID, CLEWARE_CONTACT00_PID, serial_number=self.serial)
         d.write([0, 3, on >> 8, on & 0xff, port >> 8, port & 0xff])
         d.close()
 


### PR DESCRIPTION
* This bugfix corrects the faulty usage of the variable for the Cleware UsbSwitch8's PID

Signed-off-by: Sietze van Buuren <Sietze.vanBuuren@de.bosch.com>