### PR TITLE
Remove dbname parameter from config file

### DIFF
--- a/share/pdudaemon.conf
+++ b/share/pdudaemon.conf
@@ -2,7 +2,6 @@
     "daemon": {
         "hostname": "0.0.0.0",
         "port": 16421,
-        "dbname": "pdudaemon",
         "logging_level": "DEBUG",
         "listener": "http"
     },


### PR DESCRIPTION
This is no longer used since the DB was removed in the previous commits.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>