### PR TITLE
SNMP driver improvements

### DIFF
--- a/pdudaemon/drivers/snmp.py
+++ b/pdudaemon/drivers/snmp.py
@@ -17,7 +17,6 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 #  MA 02110-1301, USA.
 
-from distutils.command.config import config
 import logging
 from pysnmp.hlapi import setCmd, SnmpEngine, UsmUserData, UdpTransportTarget, ContextData, CommunityData, ObjectType, ObjectIdentity
 import pysnmp.hlapi as pysnmp_api

--- a/pdudaemon/drivers/snmp.py
+++ b/pdudaemon/drivers/snmp.py
@@ -24,6 +24,7 @@ from pdudaemon.drivers.driver import PDUDriver, FailedRequestException, UnknownC
 import os
 log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
 
+
 class SNMP(PDUDriver):
 
     def __init__(self, hostname, settings):


### PR DESCRIPTION
Added several arguments for more flexibility in configuring SNMP devices.
Added parameters:
- inside_number: If set, replaces the * character in the "controlpoint" with the value of the variable "port". For example, if you want to change the value with numbering inside the line "_outlet1Status/outlet2Status/outlet3Status/..._"
- static_ending: If the inside_number parameter is present, a static ending is added to the end of the request. For example, if you want to change the value "outlet4Status.0". The value "0" can be written to static_ending
- auth_protocol: Authentication encryption protocol for using snmp version 3
- priv_protocol: Private encryption protocol for using snmp version 3