### PR TITLE
Add missing delay into request mode reboot command

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ Configure the PDU in the config file as usual, then launch pdudaemon with the fo
 $ pdudaemon --conf=share/pdudaemon.conf --drive --hostname pdu01 --port 1 --request reboot
 ```
 
+If requesting reboot, the delay between turning the port off and on can be modified with `--delay`
+and is by default 5 seconds.
+
 ## Adding drivers
 Drivers are implemented children of the "PDUDriver" class and many example
 implementations can be found inside the

--- a/pdudaemon/__init__.py
+++ b/pdudaemon/__init__.py
@@ -142,6 +142,7 @@ async def main_async():
     drive.add_argument("--drive", action="store_true", default=False)
     drive.add_argument("--request", dest="driverequest", action="store", type=str)
     drive.add_argument("--retries", dest="driveretries", action="store", type=int, default=5)
+    drive.add_argument("--delay", dest="drivedelay", action="store", type=int, default=5)
     drive.add_argument("--port", dest="driveport", action="store", type=str)
 
     # Parse the command line
@@ -181,6 +182,7 @@ async def main_async():
         runner = PDURunner(config, options.drivehostname, options.driveretries)
         if options.driverequest == "reboot":
             result = await runner.do_job_async(options.driveport, "off")
+            await asyncio.sleep(int(options.drivedelay))
             result = await runner.do_job_async(options.driveport, "on")
         else:
             result = await runner.do_job_async(options.driveport, options.driverequest)


### PR DESCRIPTION
Currently rebooting a device using the request mode doesn't delay in between turning the port off and on again. This can cause glitches since the device probably has some kind of holdup which may not fully drain. When pdudaemon is in daemon mode, the delay between the off and on state defaults to 5 seconds, set the same default when rebooting a port in request mode. While we are here, add an optional argument to allow the user to tweak the dwell time.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>