### PR TITLE
Support for multiple Cleware USBSwitch 4 devices

### DIFF
--- a/pdudaemon/drivers/cleware.py
+++ b/pdudaemon/drivers/cleware.py
@@ -59,7 +59,7 @@ class ClewareSwitch1Base(PDUDriver):
 
     def device_path(self):
         for dev_dict in hid.enumerate(CLEWARE_VID, CLEWARE_SWITCH1_PID):
-            serial_compare = int(dev_dict["serial_number"], 16) 
+            serial_compare = int(dev_dict["serial_number"], 16)
             if serial_compare != CLEWARE_SWITCH4_SERIAL:
                 continue
             log.debug(f"Considering serial number match: {serial_compare}")

--- a/pdudaemon/drivers/cleware.py
+++ b/pdudaemon/drivers/cleware.py
@@ -42,7 +42,7 @@ class ClewareSwitch1Base(PDUDriver):
     def __init__(self, hostname, settings):
         self.hostname = hostname
         self.settings = settings
-        self.serial = settings.get("serial", u"")
+        self.serial = int(settings.get("serial", u""))
         log.debug("serial: %s" % self.serial)
         super().__init__()
 

--- a/pdudaemon/drivers/cleware.py
+++ b/pdudaemon/drivers/cleware.py
@@ -61,6 +61,7 @@ class ClewareSwitch1Base(PDUDriver):
         for dev_dict in hid.enumerate(CLEWARE_VID, CLEWARE_SWITCH1_PID):
             if int(dev_dict["serial_number"], 16) != CLEWARE_SWITCH4_SERIAL:
                 continue
+            log.debug(f"Considering serial number match: {self.serial}")
             if self.serial == self.switch4_serial(dev_dict):
                 return dev_dict['path']
         err = f"Cleware device with serial number {self.serial} not found!"

--- a/pdudaemon/drivers/cleware.py
+++ b/pdudaemon/drivers/cleware.py
@@ -22,10 +22,12 @@
 #  MA 02110-1301, USA.
 
 import logging
-from pdudaemon.drivers.driver import PDUDriver
-from pdudaemon.drivers.hiddevice import HIDDevice
 import os
 import time
+import hid
+from pdudaemon.drivers.driver import PDUDriver
+from pdudaemon.drivers.hiddevice import HIDDevice
+
 
 log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
 

--- a/pdudaemon/drivers/cleware.py
+++ b/pdudaemon/drivers/cleware.py
@@ -59,9 +59,10 @@ class ClewareSwitch1Base(PDUDriver):
 
     def device_path(self):
         for dev_dict in hid.enumerate(CLEWARE_VID, CLEWARE_SWITCH1_PID):
-            if int(dev_dict["serial_number"], 16) != CLEWARE_SWITCH4_SERIAL:
+            serial_compare = int(dev_dict["serial_number"], 16) 
+            if serial_compare != CLEWARE_SWITCH4_SERIAL:
                 continue
-            log.debug(f"Considering serial number match: {self.serial}")
+            log.debug(f"Considering serial number match: {serial_compare}")
             if self.serial == self.switch4_serial(dev_dict):
                 return dev_dict['path']
         err = f"Cleware device with serial number {self.serial} not found!"

--- a/share/pdudaemon.conf
+++ b/share/pdudaemon.conf
@@ -89,11 +89,11 @@
         },
         "cleware-usb-switch-4": {
           "driver": "ClewareUsbSwitch4",
-          "serial": "12345"
+          "serial": 12345
         },
         "cleware-usb-switch-8": {
           "driver": "ClewareUsbSwitch8",
-          "serial": "54321"
+          "serial": 4321
         },
         "intellinet163682": {
           "driver": "intellinet",


### PR DESCRIPTION
This PR attempts to fix #118. 

This is accomplished, by using the serial number, that is printed on the device itself, instead of the serial number, that is reported by `HID`.

In order to keep things consistent, this PR also applies to Cleware USB-Switch 8 devices. That is, with this change, USB-Switch 8 devices also have to be identified with the serial number printed on the device.

Many thanks go to @sjoerdsimons, who supplied most building blocks for the PR.

Feature summary
* Fix to allow multiple Cleware USBSwitch 4 devices
* Use Cleware serial (printed on device) instead of HID serial number

Signed-off-by: Sietze van Buuren <Sietze.vanBuuren@de.bosch.com>