### PR TITLE
Use context manager to safely open/close hid devs

### DIFF
--- a/pdudaemon/drivers/cleware.py
+++ b/pdudaemon/drivers/cleware.py
@@ -23,7 +23,7 @@
 
 import logging
 from pdudaemon.drivers.driver import PDUDriver
-import hid
+from pdudaemon.drivers.hiddevice import HIDDevice
 import os
 
 log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
@@ -61,10 +61,8 @@ class ClewareSwitch1Base(PDUDriver):
             log.error("Unknown command %s." % (command))
             return
 
-        d = hid.device()
-        d.open(CLEWARE_VID, CLEWARE_SWITCH1_PID, serial_number=self.serial)
-        d.write([0, 0, port, on])
-        d.close()
+        with HIDDevice(CLEWARE_VID, CLEWARE_SWITCH1_PID, serial=self.serial) as d:
+            d.write([0, 0, port, on])
 
     @classmethod
     def accepts(cls, drivername):
@@ -103,10 +101,8 @@ class ClewareContact00Base(PDUDriver):
             log.error("Unknown command %s." % (command))
             return
 
-        d = hid.device()
-        d.open(CLEWARE_VID, CLEWARE_CONTACT00_PID, serial_number=self.serial)
-        d.write([0, 3, on >> 8, on & 0xff, port >> 8, port & 0xff])
-        d.close()
+        with HIDDevice(CLEWARE_VID, CLEWARE_CONTACT00_PID, serial=self.serial) as d:
+            d.write([0, 3, on >> 8, on & 0xff, port >> 8, port & 0xff])
 
     @classmethod
     def accepts(cls, drivername):

--- a/pdudaemon/drivers/hiddevice.py
+++ b/pdudaemon/drivers/hiddevice.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python3
+
+#  Copyright 2023 Sietze van Buuren <sietze.vanbuuren@de.bosch.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+
+import hid
+
+
+class HIDDevice:
+    def __init__(self, vid=None, pid=None, serial=None, path=None):
+        self.__dev = hid.device()
+        if path:
+            self.__dev.open_path(path)
+        elif serial:
+            self.__dev.open(vid, pid, serial)
+        elif pid and vid:
+            self.__dev.open(vid, pid, None)
+        else:
+            err = "Unable to open HID device"
+            log.error(err)
+            raise RuntimeError(err)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.__dev.close()
+
+    def write(self, buff):
+        return self.__dev.write(buff)
+
+    def read(self, max_length, timeout_ms=0):
+        return self.__dev.read(max_length, timeout_ms)

--- a/pdudaemon/drivers/ykush.py
+++ b/pdudaemon/drivers/ykush.py
@@ -24,7 +24,7 @@
 
 import logging
 from pdudaemon.drivers.driver import PDUDriver
-import hid
+from pdudaemon.drivers.hiddevice import HIDDevice
 import os
 
 log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
@@ -63,11 +63,9 @@ class YkushBase(PDUDriver):
             log.error("Unknown command %s." % (command))
             return
 
-        d = hid.device()
-        d.open(YKUSH_VID, self.ykush_pid, serial_number=self.serial)
-        d.write([byte, byte])
-        d.read(64)
-        d.close()
+        with HIDDevice(YKUSH_VID, self.ykush_pid, serial=self.serial) as d:
+            d.write([byte, byte])
+            d.read(64)
 
     @classmethod
     def accepts(cls, drivername):


### PR DESCRIPTION
This PR introduces a new `HIDDevice` class, that allows to use `with` statements for opening HID devices.

In doing so, this reduces the amount of code to write and read to HID devices, while also making it safer, since an HID device gets closed properly, even if something goes wrong during writing or reading.

NOTE: This is approach is very similar to the `Device` class of [pyhidapi](https://github.com/apmorton/pyhidapi). Unfortunately, such an approach is not available in [hidapi](https://github.com/trezor/cython-hidapi) (which is currently used in `PDUDaemon`).

Signed-off-by: Sietze van Buuren <Sietze.vanBuuren@de.bosch.com>