### PR TITLE
Add modbus support for tcp modbus relay boards

### DIFF
--- a/pdudaemon/drivers/modbustcp.py
+++ b/pdudaemon/drivers/modbustcp.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python3
+
+#
+#  Copyright 2023 Bob Clough <bob.clough@codethink.co.uk>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+
+import logging
+from pdudaemon.drivers.driver import PDUDriver
+from pymodbus.client import ModbusTcpClient
+
+import os
+log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
+
+
+class ModBusTCP(PDUDriver):
+    def __init__(self, hostname, settings):
+        self.hostname = hostname
+        self.port = settings.get("port", 502)
+        self.unit = settings.get("unit", settings.get("slave", 1))
+        self._client = ModbusTcpClient(host=self.hostname, port=self.port)
+        self._client.connect()
+        super().__init__()
+
+    def port_interaction(self, command, port_number):
+        self._client.write_coil(address=port_number, value=(command == "on"), slave=self.unit)
+
+    def _cleanup(self):
+        self._client.close()
+
+    @classmethod
+    def accepts(cls, drivername):
+        return drivername == cls.__name__.lower()

--- a/pdudaemon/drivers/strategies.py
+++ b/pdudaemon/drivers/strategies.py
@@ -70,3 +70,4 @@ from pdudaemon.drivers.intellinet import Intellinet
 from pdudaemon.drivers.esphome import ESPHomeHTTP
 from pdudaemon.drivers.servo import Servo
 from pdudaemon.drivers.ipower import LindyIPowerClassic8
+from pdudaemon.drivers.modbustcp import ModBusTCP

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyasn1
 pyusb
 pytest
 pytest-mock
+pymodbus


### PR DESCRIPTION
This is a basic module to allow control over modbus relay units, such as this [kmtronic](https://www.kmtronic.com/index.php?route=product/product&product_id=113&search=modbus) unit.

Need to do a little more testing so please don't merge yet, but any feedback would be appreciated.