### PR TITLE
Add a linter and autoformatter config

### DIFF
--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -11,13 +11,13 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-      
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,28 @@
+name: Run lint
+on: [push, workflow_dispatch, pull_request]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install pre-commit
+      run: pip install pre-commit
+
+    - name: Run pre-commit on all files
+      run: pre-commit run --all-files --show-diff-on-failure
+
+    - name: Cache the pre-commit plugins
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/pre-commit
+        key: ${{ runner.os }}-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pre-commit-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,8 +8,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Build container
         run: docker build -t pdudaemon-ci -f Dockerfile.dockerhub .
-      - name: Run pycodestyle
-        run: docker run --rm -v $(pwd):/p -w /p pdudaemon-ci /root/.local/bin/pycodestyle --config=pycodestyle_config .
       - name: Run pytest
         run: docker run -v $(pwd):/p -w /p pdudaemon-ci /root/.local/bin/pytest
       - name: Run functional tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,16 @@
 dist/
-*.pyc
 .idea/
 *.egg-info/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+# (linter) caches
+#  ruff
+.ruff_cache
+#  mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+#  pytest
+.pytest_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,43 @@
+---
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: 'v0.1.13'
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      # - id: ruff-format
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+      - id: fix-byte-order-marker
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-vcs-permalinks
+      - id: debug-statements
+      - id: check-yaml
+        files: .*\.(yaml|yml)$
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        name: codespell
+        description: Checks for common misspellings in text files.
+        entry: codespell
+        language: python
+        types: [text]
+        args: [-L, 'Hart,hart,ons']
+        require_serial: false
+        additional_dependencies: [tomli]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - .[test]
+          - types-requests
+          - types-setuptools
+          - types-paramiko

--- a/pduclient
+++ b/pduclient
@@ -96,7 +96,7 @@ if __name__ == '__main__':
             or not options.pducommand:
         print("Missing option, try -h for help")
         exit(1)
-    if not (options.pducommand in commands):
+    if options.pducommand not in commands:
         print("Unknown pdu command: %s" % options.pducommand)
         exit(1)
 

--- a/pdudaemon/__init__.py
+++ b/pdudaemon/__init__.py
@@ -31,7 +31,7 @@ from pdudaemon.httplistener import HTTPListener
 from pdudaemon.pdurunner import PDURunner
 from pdudaemon.drivers.driver import PDUDriver
 
-assert PDUDriver, "Imported for user convenience."
+assert PDUDriver, "Imported for user convenience." # type: ignore[truthy-function]
 
 ###########
 # Constants

--- a/pdudaemon/__init__.py
+++ b/pdudaemon/__init__.py
@@ -20,19 +20,18 @@
 
 import argparse
 import asyncio
-import contextlib
 import json
 import logging
 from logging.handlers import WatchedFileHandler
 import signal
 import sys
-import time
 
 from pdudaemon.tcplistener import TCPListener
 from pdudaemon.httplistener import HTTPListener
 from pdudaemon.pdurunner import PDURunner
 from pdudaemon.drivers.driver import PDUDriver
 
+assert PDUDriver, "Imported for user convenience."
 
 ###########
 # Constants

--- a/pdudaemon/drivers/bcu.py
+++ b/pdudaemon/drivers/bcu.py
@@ -26,7 +26,7 @@ log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
 
 
 class BCU(PDUDriver):
-    """PDUDriver implementation using NXP BCU
+    """PDUDriver implementation using NXP BCU.
 
     The NXP BCU tool can be used for remote power control on some newer NXP
     development boards.

--- a/pdudaemon/drivers/cleware.py
+++ b/pdudaemon/drivers/cleware.py
@@ -40,7 +40,7 @@ CLEWARE_NEW_SWITCH_SERIAL = 0x63813
 
 class ClewareBase(PDUDriver):
     """Base class for Cleware USB-Switch drivers."""
-    switch_pid = None
+    switch_pid = None  # type: int
     connection = None
     port_count = 0
 

--- a/pdudaemon/drivers/cleware.py
+++ b/pdudaemon/drivers/cleware.py
@@ -39,7 +39,7 @@ CLEWARE_NEW_SWITCH_SERIAL = 0x63813
 
 
 class ClewareBase(PDUDriver):
-    """ Base class for Cleware USB-Switch drivers """
+    """Base class for Cleware USB-Switch drivers."""
     switch_pid = None
     connection = None
     port_count = 0
@@ -52,7 +52,7 @@ class ClewareBase(PDUDriver):
         super().__init__()
 
     def new_switch_serial(self, device_path):
-        """ Find the correct serial for novel Cleware USB Switch devices """
+        """Find the correct serial for novel Cleware USB Switch devices."""
         with HIDDevice(path=device_path) as dev:
             serial = 0
             for i in range(8, 15):
@@ -62,7 +62,7 @@ class ClewareBase(PDUDriver):
         return serial
 
     def device_path(self):
-        """ Search and return the matching device path """
+        """Search and return the matching device path."""
         for dev_dict in hid.enumerate(CLEWARE_VID, self.switch_pid):
             device_path = dev_dict['path']
             serial_compare = int(dev_dict["serial_number"], 16)

--- a/pdudaemon/drivers/conrad197720.py
+++ b/pdudaemon/drivers/conrad197720.py
@@ -69,7 +69,7 @@ class Conrad197720(PDUDriver):
     https://www.conrad.com/p/conrad-components-197730-relay-card-component-12-v-dc-197730
 
     Up to 255 relay cards can be used on one serial port
-    The difference between model 197720 and model 197730 is the switchting power of the relays
+    The difference between model 197720 and model 197730 is the switching power of the relays
     The protocol is the same for both card types
     """
     def __init__(self, hostname, settings):
@@ -162,7 +162,7 @@ class Conrad197720(PDUDriver):
         """Private function to check the XOR checksum of the received frame.
 
         :param self: The object itself
-        :param data: The array holding the received data bytes, lenght must be a multiple of FRAME_SIZE
+        :param data: The array holding the received data bytes, length must be a multiple of FRAME_SIZE
         :return: True, if checksum(s) match
         :rtype: boolean
         """

--- a/pdudaemon/drivers/conrad197720.py
+++ b/pdudaemon/drivers/conrad197720.py
@@ -166,7 +166,6 @@ class Conrad197720(PDUDriver):
         :return: True, if checksum(s) match
         :rtype: boolean
         """
-        recv = ""
         if len(data) % FRAME_SIZE != 0 or len(data) == 0:
             return False
         for i in range(0, int(len(data) / FRAME_SIZE)):

--- a/pdudaemon/drivers/conrad197720.py
+++ b/pdudaemon/drivers/conrad197720.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
-"""
-#
-# Copyright 2023 Joachim Schiffer <joachim.schiffer@bosch.com>
+"""#
+# Copyright 2023 Joachim Schiffer <joachim.schiffer@bosch.com>.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -64,7 +63,7 @@ OPTION_BROADCAST_SEND_AND_BLOCK = 3
 
 
 class Conrad197720(PDUDriver):
-    """Driver for Conrad Components 197720 and 197730 relay card
+    """Driver for Conrad Components 197720 and 197730 relay card.
 
     https://www.conrad.com/p/conrad-components-197720-relay-card-component-12-v-dc-24-v-dc-197720
     https://www.conrad.com/p/conrad-components-197730-relay-card-component-12-v-dc-197730
@@ -81,6 +80,7 @@ class Conrad197720(PDUDriver):
         self.__init()
 
     def __del__(self):
+        """Cleanup on delete."""
         if self.com.is_open:
             self.com.close()
 
@@ -89,8 +89,8 @@ class Conrad197720(PDUDriver):
         return drivername == "conrad197720"
 
     def port_interaction(self, command, port_number):
-        """
-        pdudaemon method for port interaction
+        """Pdudaemon method for port interaction.
+
         :param self: The object itself
         :param command: The command string
         :param port_number: The port number 0...n
@@ -99,8 +99,8 @@ class Conrad197720(PDUDriver):
         self.__updateSingle(command, port_number)
 
     def getNumPorts(self):
-        """
-        Return amount of ports available
+        """Return amount of ports available.
+
         :param self: The object itself
         :return: number of ports
         :rtype: int
@@ -108,8 +108,8 @@ class Conrad197720(PDUDriver):
         return self.num_cards * PORTS_PER_CARD
 
     def __txFrame(self, tx_data):
-        """
-        Private function to send an array of data bytes
+        """Private function to send an array of data bytes.
+
         :param self: The object itself
         :param tx_data: The array of data bytes to send
         :raises RuntimeError: tx_data array too big
@@ -124,8 +124,8 @@ class Conrad197720(PDUDriver):
         log.debug(f"sent: {tx_data}")
 
     def __txSingleByte(self):
-        """
-        Private function to send a single byte
+        """Private function to send a single byte.
+
         The card(s) always send and receive frames of FRAME_SIZE bytes,
         if this is not in sync, this function can be used to send single
         bytes, until a correct answer is received. In theory this
@@ -139,8 +139,8 @@ class Conrad197720(PDUDriver):
         log.debug("sent single byte")
 
     def __rxFrame(self, num_frames):
-        """
-        Private function to receive frame(s)
+        """Private function to receive frame(s).
+
         :param self: The object itself
         :param num_frames: The number of frames to wait for (until timeout SERIAL_TIMEOUT occurs)
         :return: The received data
@@ -159,8 +159,8 @@ class Conrad197720(PDUDriver):
         return rx_data
 
     def __checkFrameChecksum(self, data):
-        """
-        Private function to check the XOR checksum of the received frame
+        """Private function to check the XOR checksum of the received frame.
+
         :param self: The object itself
         :param data: The array holding the received data bytes, lenght must be a multiple of FRAME_SIZE
         :return: True, if checksum(s) match
@@ -178,8 +178,8 @@ class Conrad197720(PDUDriver):
         return True
 
     def __sendCommand(self, cmd_byte, addr_byte, data_byte):
-        """
-        Private function to send a command to the card(s) / retry / parse the response
+        """Private function to send a command to the card(s) / retry / parse the response.
+
         :param self: The object itself
         :param cmd_byte: The command to the card(s)
         :param addr_byte: The card address, used when more than one relay card is connected to the same serial port
@@ -222,8 +222,8 @@ class Conrad197720(PDUDriver):
         raise RuntimeError("All retries failed, communication error")
 
     def __checkNumCards(self, data):
-        """
-        Private function to parse the amount of concatenated card at this serial port
+        """Private function to parse the amount of concatenated card at this serial port.
+
         :param self: The object itself
         :return: number of cards
         :rtype: int
@@ -236,8 +236,8 @@ class Conrad197720(PDUDriver):
         return self.num_cards
 
     def __getNumCards(self):
-        """
-        Return amount of cards found after init()
+        """Return amount of cards found after init().
+
         :param self: The object itself
         :return: number of cards
         :rtype: int
@@ -245,8 +245,8 @@ class Conrad197720(PDUDriver):
         return self.num_cards
 
     def __openConnection(self, portname):
-        """
-        Open serial connection
+        """Open serial connection.
+
         :param self: The object itself
         :param portname: The string describing the serial device to open (e.g. "/dev/ttyUSB1" or "/dev/serial/by-id/...")
         """
@@ -260,8 +260,8 @@ class Conrad197720(PDUDriver):
         self.com.open()
 
     def __init(self):
-        """
-        Init all cards
+        """Init all cards.
+
         :param self: The object itself
         :raises RuntimeError: all retries failed, communication error
         """
@@ -275,8 +275,8 @@ class Conrad197720(PDUDriver):
                 self.__sendCommand(CMD_SETOPTION, card_addr, OPTION_BROADCAST_SEND_AND_NO_BLOCK)
 
     def __updateSingle(self, command, port):
-        """
-        Update a single port of a card
+        """Update a single port of a card.
+
         :param self: The object itself
         :param command: The command to execute, "on" "off" or "toggle"
         :param port: The port number 0..n, all ports of all cards are in one range, e.g. port 9 is the second port of the second card

--- a/pdudaemon/drivers/devantechusb.py
+++ b/pdudaemon/drivers/devantechusb.py
@@ -32,7 +32,7 @@ log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
 class DevantechusbBase(PDUDriver):
     connection = None
     port_count = 0
-    supported = []
+    supported = []  # type: list[str]
 
     def __init__(self, hostname, settings):
         self.hostname = hostname

--- a/pdudaemon/drivers/egpms.py
+++ b/pdudaemon/drivers/egpms.py
@@ -24,7 +24,6 @@
 import logging
 from pdudaemon.drivers.driver import PDUDriver
 import socket
-import sys
 from array import array
 
 import os

--- a/pdudaemon/drivers/energenieusb.py
+++ b/pdudaemon/drivers/energenieusb.py
@@ -103,8 +103,8 @@ class EnerGenieUSB(PDUDriver):
     # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
     def connect(self):
-        """
-        Returns the list of compatible devices.
+        """Returns the list of compatible devices.
+
         @return: device list
         """
         ret = list()
@@ -116,8 +116,8 @@ class EnerGenieUSB(PDUDriver):
         return ret
 
     def getid(self, dev):
-        """
-        Gets the id of a device.
+        """Gets the id of a device.
+
         @return: id
         """
         buf = bytes([0x00, 0x00, 0x00, 0x00, 0x00])
@@ -133,8 +133,8 @@ class EnerGenieUSB(PDUDriver):
         return ret
 
     def switchoff(self, dev, i):
-        """
-        Switches outlet i of the device off.
+        """Switches outlet i of the device off.
+
         @param dev: device
         @param i: outlet
         """
@@ -142,8 +142,8 @@ class EnerGenieUSB(PDUDriver):
         buf = dev.ctrl_transfer(0x21, 0x09, 0x0300 + 3 * i, 0, buf, 500)
 
     def switchon(self, dev, i):
-        """
-        Switches outlet i of the device on.
+        """Switches outlet i of the device on.
+
         @param dev: device
         @param i: outlet
         """

--- a/pdudaemon/drivers/gude1202.py
+++ b/pdudaemon/drivers/gude1202.py
@@ -52,7 +52,7 @@ class Gude1202(PDUDriver):
         elif command == "off":
             self.connection.send("port %s state set 0\r" % port_number)
         else:
-            log.error("Unkown command")
+            log.error("Unknown command")
 
         self.connection.expect("OK.")
 

--- a/pdudaemon/drivers/hiddevice.py
+++ b/pdudaemon/drivers/hiddevice.py
@@ -39,9 +39,11 @@ class HIDDevice:
             raise RuntimeError(err)
 
     def __enter__(self):
+        """Open and Return HID Device."""
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
+        """Close HID Device."""
         self.__dev.close()
 
     def write(self, buff):

--- a/pdudaemon/drivers/intellinet.py
+++ b/pdudaemon/drivers/intellinet.py
@@ -33,8 +33,7 @@ __manual__ = "https://s3.amazonaws.com/assets.mhint/downloads/61413/INT_163682_U
 
 
 class Intellinet(PDUDriver):
-    """
-    Intellinet 163682 support
+    """Intellinet 163682 support.
 
     See also https://github.com/01programs/Intellinet_163682_IP_smart_PDU_API
     """

--- a/pdudaemon/drivers/localbase.py
+++ b/pdudaemon/drivers/localbase.py
@@ -19,9 +19,7 @@
 #  MA 02110-1301, USA.
 
 import logging
-import pexpect
 from pdudaemon.drivers.driver import PDUDriver
-import sys
 import os
 log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
 

--- a/pdudaemon/drivers/netio4.py
+++ b/pdudaemon/drivers/netio4.py
@@ -54,7 +54,7 @@ class Netio4(PDUDriver):
         elif command == "off":
             self.connection.send("port %s 0\r" % port_number)
         else:
-            log.error("Unkown command")
+            log.error("Unknown command")
 
         self.connection.expect("250 OK")
 

--- a/pdudaemon/drivers/numatousb.py
+++ b/pdudaemon/drivers/numatousb.py
@@ -24,7 +24,7 @@ log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
 
 
 class NumatoUSB(PDUDriver):
-    """Supports various numato USB relay modules
+    """Supports various numato USB relay modules.
 
     Comes in many variants with similar protocols
 

--- a/pdudaemon/drivers/strategies.py
+++ b/pdudaemon/drivers/strategies.py
@@ -18,24 +18,24 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 #  MA 02110-1301, USA.
 
-from pdudaemon.drivers.acme import ACME  # pylint: disable=W0611
-from pdudaemon.drivers.anelnetpwrctrl import AnelNETPwrCtrlHOME  # pylint: disable=W0611
-from pdudaemon.drivers.anelnetpwrctrl import AnelNETPwrCtrlADV  # pylint: disable=W0611
-from pdudaemon.drivers.anelnetpwrctrl import AnelNETPwrCtrlIO  # pylint: disable=W0611
-from pdudaemon.drivers.anelnetpwrctrl import AnelNETPwrCtrlPRO  # pylint: disable=W0611
-from pdudaemon.drivers.apc7900 import APC7900  # pylint: disable=W0611
-from pdudaemon.drivers.apc7932 import APC7932  # pylint: disable=W0611
-from pdudaemon.drivers.apc7952 import APC7952  # pylint: disable=W0611
-from pdudaemon.drivers.apc9218 import APC9218  # pylint: disable=W0611
-from pdudaemon.drivers.apc8959 import APC8959  # pylint: disable=W0611
-from pdudaemon.drivers.apc9210 import APC9210  # pylint: disable=W0611
-from pdudaemon.drivers.apc7920 import APC7920  # pylint: disable=W0611
-from pdudaemon.drivers.apc7921 import APC7921  # pylint: disable=W0611
+from pdudaemon.drivers.acme import ACME
+from pdudaemon.drivers.anelnetpwrctrl import AnelNETPwrCtrlHOME
+from pdudaemon.drivers.anelnetpwrctrl import AnelNETPwrCtrlADV
+from pdudaemon.drivers.anelnetpwrctrl import AnelNETPwrCtrlIO
+from pdudaemon.drivers.anelnetpwrctrl import AnelNETPwrCtrlPRO
+from pdudaemon.drivers.apc7900 import APC7900
+from pdudaemon.drivers.apc7932 import APC7932
+from pdudaemon.drivers.apc7952 import APC7952
+from pdudaemon.drivers.apc9218 import APC9218
+from pdudaemon.drivers.apc8959 import APC8959
+from pdudaemon.drivers.apc9210 import APC9210
+from pdudaemon.drivers.apc7920 import APC7920
+from pdudaemon.drivers.apc7921 import APC7921
 from pdudaemon.drivers.cleware import ClewareUsbSwitch4
 from pdudaemon.drivers.conrad197720 import Conrad197720
-from pdudaemon.drivers.ubiquity import Ubiquity3Port  # pylint: disable=W0611
-from pdudaemon.drivers.ubiquity import Ubiquity6Port  # pylint: disable=W0611
-from pdudaemon.drivers.ubiquity import Ubiquity8Port  # pylint: disable=W0611
+from pdudaemon.drivers.ubiquity import Ubiquity3Port
+from pdudaemon.drivers.ubiquity import Ubiquity6Port
+from pdudaemon.drivers.ubiquity import Ubiquity8Port
 from pdudaemon.drivers.localcmdline import LocalCmdline
 from pdudaemon.drivers.ip9258 import IP9258
 from pdudaemon.drivers.sainsmart import Sainsmart
@@ -54,10 +54,10 @@ from pdudaemon.drivers.numatousb import NumatoUSB8
 from pdudaemon.drivers.numatousb import NumatoUSB16
 from pdudaemon.drivers.numatousb import NumatoUSB32
 from pdudaemon.drivers.numatousb import NumatoUSB64
-from pdudaemon.drivers.servertechpro2 import ServerTechPro2  # pylint: disable=W0611
+from pdudaemon.drivers.servertechpro2 import ServerTechPro2
 from pdudaemon.drivers.synaccess import SynNetBooter
-from pdudaemon.drivers.tasmota import SonoffS20Tasmota  # pylint: disable=W0611
-from pdudaemon.drivers.tasmota import BrennenstuhlWSPL01Tasmota  # pylint: disable=W0611
+from pdudaemon.drivers.tasmota import SonoffS20Tasmota
+from pdudaemon.drivers.tasmota import BrennenstuhlWSPL01Tasmota
 from pdudaemon.drivers.egpms import EgPMS
 from pdudaemon.drivers.ykush import YkushXS
 from pdudaemon.drivers.ykush import Ykush
@@ -74,3 +74,62 @@ from pdudaemon.drivers.ipower import LindyIPowerClassic8
 from pdudaemon.drivers.modbustcp import ModBusTCP
 from pdudaemon.drivers.gude1202 import Gude1202
 from pdudaemon.drivers.netio4 import Netio4
+
+__all__ = [
+    ACME.__name__,
+    AnelNETPwrCtrlHOME.__name__,
+    AnelNETPwrCtrlADV.__name__,
+    AnelNETPwrCtrlIO.__name__,
+    AnelNETPwrCtrlPRO.__name__,
+    APC7900.__name__,
+    APC7932.__name__,
+    APC7952.__name__,
+    APC9218.__name__,
+    APC8959.__name__,
+    APC9210.__name__,
+    APC7920.__name__,
+    APC7921.__name__,
+    ClewareUsbSwitch4.__name__,
+    Conrad197720.__name__,
+    Ubiquity3Port.__name__,
+    Ubiquity6Port.__name__,
+    Ubiquity8Port.__name__,
+    LocalCmdline.__name__,
+    IP9258.__name__,
+    Sainsmart.__name__,
+    DevantechETH002.__name__,
+    DevantechETH0621.__name__,
+    DevantechETH484.__name__,
+    DevantechETH008.__name__,
+    DevantechETH8020.__name__,
+    DevantechDS2824.__name__,
+    DevantechUSB2.__name__,
+    DevantechUSB8.__name__,
+    NumatoUSB1.__name__,
+    NumatoUSB2.__name__,
+    NumatoUSB4.__name__,
+    NumatoUSB8.__name__,
+    NumatoUSB16.__name__,
+    NumatoUSB32.__name__,
+    NumatoUSB64.__name__,
+    ServerTechPro2.__name__,
+    SynNetBooter.__name__,
+    SonoffS20Tasmota.__name__,
+    BrennenstuhlWSPL01Tasmota.__name__,
+    EgPMS.__name__,
+    YkushXS.__name__,
+    Ykush.__name__,
+    SNMP.__name__,
+    EnerGenieUSB.__name__,
+    BCU.__name__,
+    VUSBHID.__name__,
+    TPLink.__name__,
+    ip9850.__name__,
+    Intellinet.__name__,
+    ESPHomeHTTP.__name__,
+    Servo.__name__,
+    LindyIPowerClassic8.__name__,
+    ModBusTCP.__name__,
+    Gude1202.__name__,
+    Netio4.__name__,
+]

--- a/pdudaemon/drivers/synaccess.py
+++ b/pdudaemon/drivers/synaccess.py
@@ -20,7 +20,6 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 #  MA 02110-1301, USA.
 
-import sys
 import logging
 import pexpect
 from pdudaemon.drivers.driver import PDUDriver

--- a/pdudaemon/drivers/tasmota.py
+++ b/pdudaemon/drivers/tasmota.py
@@ -32,7 +32,7 @@ log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
 
 
 class TasmotaBase(PDUDriver):
-    port_count = None
+    port_count = None  # type: int
 
     def __init__(self, hostname, settings):
         self.hostname = hostname

--- a/pdudaemon/drivers/test_numatousb.py
+++ b/pdudaemon/drivers/test_numatousb.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest import mock
 from .numatousb import NumatoUSB4
 from .numatousb import NumatoUSB32

--- a/pdudaemon/drivers/tplink.py
+++ b/pdudaemon/drivers/tplink.py
@@ -117,4 +117,4 @@ class TPLink(PDUDriver):
             }
         }
         log.debug(datadict)
-        res = self.send_command(json.dumps(datadict))
+        self.send_command(json.dumps(datadict))

--- a/pdudaemon/drivers/ykush.py
+++ b/pdudaemon/drivers/ykush.py
@@ -37,7 +37,7 @@ YKUSH3_PID = 0xf11b
 
 class YkushBase(PDUDriver):
     connection = None
-    ykush_pid = None
+    ykush_pid = None  # type: int
     port_count = 0
 
     def __init__(self, hostname, settings):

--- a/pdudaemon/listener.py
+++ b/pdudaemon/listener.py
@@ -48,7 +48,6 @@ def parse_tcp(data):
 
 def parse_http(data, path):
     args = Args()
-    delay = None
     entry = path.lstrip('/').split('/')
     if len(entry) != 3:
         logger.info("Request path was invalid: %s", entry)

--- a/pdudaemon/listener.py
+++ b/pdudaemon/listener.py
@@ -94,7 +94,7 @@ async def process_request(args, config, daemon):
     if args.hostname not in config['pdus']:
         logger.info("PDU was not found in config")
         return False
-    if not (args.request in ["reboot", "on", "off"]):
+    if args.request not in ["reboot", "on", "off"]:
         logger.info("Unknown request: %s", args.request)
         return False
     runner = daemon.runners[args.hostname]

--- a/pdudaemon/pdurunner.py
+++ b/pdudaemon/pdurunner.py
@@ -25,8 +25,9 @@ import traceback
 import pexpect
 import concurrent.futures
 from pdudaemon.drivers.driver import PDUDriver
-import pdudaemon.drivers.strategies  # pylint: disable=W0611
+import pdudaemon.drivers.strategies
 
+assert pdudaemon.drivers.strategies, "Subclasses are iterated to find all drivers"
 
 class PDURunner:
 

--- a/pdudaemon/tcplistener.py
+++ b/pdudaemon/tcplistener.py
@@ -21,7 +21,6 @@
 import asyncio
 import logging
 import socket
-import time
 import pdudaemon.listener as listener
 logger = logging.getLogger('pdud.tcp')
 

--- a/pycodestyle_config
+++ b/pycodestyle_config
@@ -1,3 +1,0 @@
-[pycodestyle]
-show-source = True
-ignore = E501,W503

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ select = [
   "W", # pycodestyle
   "D", # pydocstyle
   "F", # pyflakes
-  "I", # isort
+  # "I", # isort
   # "UP", # pyupgrade
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,36 @@ requires = [
     "setuptools>=61.0"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+select = [
+  "E", # pycodestyle
+  "W", # pycodestyle
+  "D", # pydocstyle
+  "F", # pyflakes
+  "I", # isort
+  # "UP", # pyupgrade
+]
+ignore = [
+  "D100", # Missing docstring in public module
+  "D101", # Missing docstring in public class
+  "D102", # Missing docstring in public method
+  "D103", # Missing docstring in public function
+  "D104", # Missing docstring in public package
+  "D107", # Missing docstring in `__init__`
+  "D205", # 1 blank line required between summary line and description
+  "E501", # Line too long
+]
+
+src = ["pdudaemon", "tests"]
+
+line-length = 88 # Match black
+
+# Minimum Python 3.8.
+target-version = "py38"
+
+[tool.ruff.isort]
+known-first-party = ["pdudaemon", "tests"]
+
+[tool.ruff.pydocstyle]
+convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ packages = [
 [project.urls]
 Homepage = "https://github.com/pdudaemon/pdudaemon.git"
 
-[project.entry-points.console_scripts]
+[project.scripts]
 pdudaemon = "pdudaemon:main"
 
 [build-system]

--- a/share/80-vusbhid.rules
+++ b/share/80-vusbhid.rules
@@ -1,3 +1,2 @@
 # V-USB HID Relays
 SUBSYSTEM=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="05df", MODE="666"
-


### PR DESCRIPTION
Hi @mattface! Sorry if this is an unsolicited PR, but I noticed some commits that were fixing code style, I thought I would offer a suggestion using the [pre-commit.ci](https://pre-commit.ci/)/ framework (free for open source repositories), that would allow linting for each PR

> [!NOTE]
> This PR originally suggested the use of the pre-commit.ci GHA, but has implemented a proof of concept which runs it in the normal github workflow file.

## Summary of changes
1. Add a pre-commit config
2. Run pre-commit on files to lint for codestyle and some other lint errors
3. Provisioned some entries (but commented out) for full autoformatting ~~and type checking - but this would likely need a bit more work~~


I will add some review comments to explain some elements on the proposal, but hopefully this can help ensure the consistent code quality.