### PR TITLE
Add drivers for Gude Expert Power Control 1202 and Netio 4

### DIFF
--- a/pdudaemon/drivers/gude1202.py
+++ b/pdudaemon/drivers/gude1202.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python3
+
+#  Copyright (c) 2023 Koninklijke Philips N.V.
+#  Author Julian Haller <julian.haller@philips.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+
+import logging
+import pexpect
+from pdudaemon.drivers.driver import PDUDriver
+import os
+
+log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
+
+
+class Gude1202(PDUDriver):
+    connection = None
+
+    def __init__(self, hostname, settings):
+        self.hostname = hostname
+        self.settings = settings
+        telnetport = settings.get("telnetport", 23)
+
+        self.exec_string = "/usr/bin/telnet %s %d" % (hostname, telnetport)
+        super(Gude1202, self).__init__()
+
+    @classmethod
+    def accepts(cls, drivername):
+        if drivername == "gude1202":
+            return True
+        return False
+
+    def port_interaction(self, command, port_number):
+        log.debug("Running port_interaction")
+        self.get_connection()
+        log.debug("Attempting command: {} port: {}".format(command, port_number))
+        if command == "on":
+            self.connection.send("port %s state set 1\r" % port_number)
+        elif command == "off":
+            self.connection.send("port %s state set 0\r" % port_number)
+        else:
+            log.error("Unkown command")
+
+        self.connection.expect("OK.")
+
+    def get_connection(self):
+        log.debug("Connecting to Gude1202 PDU with: %s", self.exec_string)
+        self.connection = pexpect.spawn(self.exec_string)
+
+    def _cleanup(self):
+        if self.connection:
+            self._pdu_logout()
+            self.connection.close()
+
+    def _bombout(self):
+        if self.connection:
+            self.connection.close(force=True)
+
+    def _pdu_logout(self):
+        log.debug("Logging out")
+        self.connection.send("quit\r")

--- a/pdudaemon/drivers/netio4.py
+++ b/pdudaemon/drivers/netio4.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python3
+
+#  Copyright (c) 2023 Koninklijke Philips N.V.
+#  Author Julian Haller <julian.haller@philips.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+
+import logging
+import pexpect
+from pdudaemon.drivers.driver import PDUDriver
+import os
+
+log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
+
+
+class Netio4(PDUDriver):
+    connection = None
+
+    def __init__(self, hostname, settings):
+        self.hostname = hostname
+        self.settings = settings
+        self.username = settings.get("username", "admin")
+        self.password = settings.get("password", "admin")
+        telnetport = settings.get("telnetport", 1234)
+
+        self.exec_string = "/usr/bin/telnet %s %d" % (hostname, telnetport)
+        super(Netio4, self).__init__()
+
+    @classmethod
+    def accepts(cls, drivername):
+        if drivername == "netio4":
+            return True
+        return False
+
+    def port_interaction(self, command, port_number):
+        log.debug("Running port_interaction")
+        self.get_connection()
+        log.debug("Attempting command: {} port: {}".format(command, port_number))
+        if command == "on":
+            self.connection.send("port %s 1\r" % port_number)
+        elif command == "off":
+            self.connection.send("port %s 0\r" % port_number)
+        else:
+            log.error("Unkown command")
+
+        self.connection.expect("250 OK")
+
+    def get_connection(self):
+        log.debug("Connecting to Netio4 PDU with: %s", self.exec_string)
+        self.connection = pexpect.spawn(self.exec_string)
+        self._pdu_login(self.username, self.password)
+
+    def _cleanup(self):
+        if self.connection:
+            self._pdu_logout()
+            self.connection.close()
+
+    def _bombout(self):
+        if self.connection:
+            self.connection.close(force=True)
+
+    def _pdu_login(self, username, password):
+        log.debug("attempting login with username %s, password %s", username, password)
+        self.connection.send("\r")
+        self.connection.expect("502 UNKNOWN COMMAND")
+        self.connection.send("login %s %s\r" % (username, password))
+        self.connection.expect("250 OK")
+
+    def _pdu_logout(self):
+        log.debug("Logging out")
+        self.connection.send("quit\r")
+        self.connection.expect("110 BYE")

--- a/pdudaemon/drivers/strategies.py
+++ b/pdudaemon/drivers/strategies.py
@@ -72,3 +72,4 @@ from pdudaemon.drivers.servo import Servo
 from pdudaemon.drivers.ipower import LindyIPowerClassic8
 from pdudaemon.drivers.modbustcp import ModBusTCP
 from pdudaemon.drivers.gude1202 import Gude1202
+from pdudaemon.drivers.netio4 import Netio4

--- a/pdudaemon/drivers/strategies.py
+++ b/pdudaemon/drivers/strategies.py
@@ -71,3 +71,4 @@ from pdudaemon.drivers.esphome import ESPHomeHTTP
 from pdudaemon.drivers.servo import Servo
 from pdudaemon.drivers.ipower import LindyIPowerClassic8
 from pdudaemon.drivers.modbustcp import ModBusTCP
+from pdudaemon.drivers.gude1202 import Gude1202


### PR DESCRIPTION
The Gude Expert Power Control 1202 is a 4 port 230V PDU. The vendor
offers 3 variants:

- 1202-1: type F socket connectors (DE)
- 1202-3: type J socket connectors (CH)
- 1202-4: IEC C13 connectors

The driver was tested with the 1202-1 variant, however the protocol
looks identical for all 3 variants.

---

The Netio 4 family of 4 port 230V PDUs consists of various (slightly
different) variants, all offering the same telnet interface to switch
the power outlets. While the Netio 4 family was obsoleted, a successor
is available in form of the Netio PowerBOX 4KF. According to vendor
information, the telnet interface is backwards compatible to the one of
the Netio 4 devices. However, I don't have such a device at hand, thus
marking the driver as Netio 4 compatible only.