### PR TITLE
Add missing log variable

### DIFF
--- a/pdudaemon/drivers/hiddevice.py
+++ b/pdudaemon/drivers/hiddevice.py
@@ -23,6 +23,7 @@ import hid
 
 log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
 
+
 class HIDDevice:
     def __init__(self, vid=None, pid=None, serial=None, path=None):
         self.__dev = hid.device()

--- a/pdudaemon/drivers/hiddevice.py
+++ b/pdudaemon/drivers/hiddevice.py
@@ -17,8 +17,11 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 #  MA 02110-1301, USA.
 
+import os
+import logging
 import hid
 
+log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
 
 class HIDDevice:
     def __init__(self, vid=None, pid=None, serial=None, path=None):


### PR DESCRIPTION
Add the missing log variable to the `hiddevice` module, by making the appropriate call to the logging package.