### PR TITLE
Add new workflow to push latest commit to dockerhub

### DIFF
--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -1,0 +1,27 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile.dockerhub
+          push: true
+          tags: pdudaemon/pdudaemon:latest


### PR DESCRIPTION
While we get sorted with tagging/releases, we should at least update the dockerhub image since it's very out of date. Add a workflow job that pushes to dockerhub using credentials from repo secrets.