### PR TITLE
Fix: Allow non-numeric port identifiers

### DIFF
--- a/pdudaemon/drivers/esphome.py
+++ b/pdudaemon/drivers/esphome.py
@@ -65,7 +65,7 @@ class ESPHomeHTTP(PDUDriver):
             err = "Port number must be in range 1 - {}".format(self.port_count)
             log.error(err)
             raise FailedRequestException(err)
-        esphome_entity_id = self.switch_ids[port_number - 1]
+        esphome_entity_id = self.switch_ids[int(port_number) - 1]
 
         # Build the POST request
         # url should be in the format http://{hostname}/switch/{id}/{cmd}

--- a/pdudaemon/drivers/modbustcp.py
+++ b/pdudaemon/drivers/modbustcp.py
@@ -36,6 +36,7 @@ class ModBusTCP(PDUDriver):
         super().__init__()
 
     def port_interaction(self, command, port_number):
+        port_number = int(port_number)
         self._client.write_coil(address=port_number, value=(command == "on"), slave=self.unit)
 
     def _cleanup(self):

--- a/pdudaemon/listener.py
+++ b/pdudaemon/listener.py
@@ -100,11 +100,11 @@ async def process_request(args, config, daemon):
     runner = daemon.runners[args.hostname]
     if args.request == "reboot":
         logger.debug("reboot requested, submitting off/on")
-        await runner.do_job_async(int(args.port), "off")
+        await runner.do_job_async(args.port, "off")
         await asyncio.sleep(int(args.delay))
-        await runner.do_job_async(int(args.port), "on")
+        await runner.do_job_async(args.port, "on")
         return True
     else:
         await asyncio.sleep(int(args.delay))
-        await runner.do_job_async(int(args.port), args.request)
+        await runner.do_job_async(args.port, args.request)
         return True


### PR DESCRIPTION
Previously enabled in commit da3238cc9b8fefbdc2f4f87683c987779f3358c2 but broken in recent changes.