### PR TITLE
esphome: Use entity_id string to identify port rather than a port number

### DIFF
--- a/pdudaemon/drivers/esphome.py
+++ b/pdudaemon/drivers/esphome.py
@@ -42,17 +42,9 @@ class ESPHomeHTTP(PDUDriver):
         self.username = settings.get("username")
         self.password = settings.get("password")
 
-        self.switch_ids = settings.get("switch_ids")
-        if self.switch_ids is None:
-            raise RuntimeError(
-                "No switch entity ID defined for %s. Provide `switch_ids` configuration entry with a list of switch IDs."
-                % self.hostname
-            )
-        self.port_count = len(self.switch_ids)
-
         super().__init__()
 
-    def port_interaction(self, command, port_number):
+    def port_interaction(self, command, esphome_entity_id):
         esphome_cmd = ""
         if command == "on":
             esphome_cmd = "turn_on"
@@ -60,12 +52,6 @@ class ESPHomeHTTP(PDUDriver):
             esphome_cmd = "turn_off"
         else:
             raise FailedRequestException("Unknown command %s" % (command))
-
-        if int(port_number) > self.port_count or int(port_number) < 1:
-            err = "Port number must be in range 1 - {}".format(self.port_count)
-            log.error(err)
-            raise FailedRequestException(err)
-        esphome_entity_id = self.switch_ids[int(port_number) - 1]
 
         # Build the POST request
         # url should be in the format http://{hostname}/switch/{id}/{cmd}

--- a/share/pdudaemon.conf
+++ b/share/pdudaemon.conf
@@ -131,10 +131,7 @@
         "esphome": {
             "driver": "esphome-http",
             "username": "admin",
-            "password": "web",
-            "switch_ids": [
-                "relay_1"
-            ]
+            "password": "web"
         },
         "servo": {
             "driver": "SERVO",


### PR DESCRIPTION
The esphome driver currently requires an array in the configuration called
switch_ids which really is a mapping of port number -> ESPHome entity_id.

In https://github.com/pdudaemon/pdudaemon/pull/135 pdudaemon gained support for the ability to directly pass as
string as the port name rather than just numbers. Let's simplify the driver
such that we don't need the mapping table and just allow users to pass the
entity_id as the port name.

This may break existing users of the esphome driver as instead pdudaemon
will now pass the port number directly to esphome rather than the mapping
in the configuration file, but esphome will return a 404 error so that can
easily be detected. Since I am probably the only user of the esphome driver
in pdudaemon, I am happy to mark this as a breaking change.

Fixes: https://github.com/pdudaemon/pdudaemon/issues/138