### PR TITLE
setup.py: Add missing requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         ]
     },
     install_requires=[
+        "aiohttp",
         "requests",
         "pexpect",
         "systemd_python",
@@ -64,7 +65,8 @@ setup(
         "hidapi",
         "pysnmp",
         "pyasn1",
-        "pyusb"
+        "pyusb",
+        "pymodbus",
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
aiohttp and pymodbus are needed at runtime, so lets add them to setup.py. This also helps the debian packaging as the helpers generate the dependency list based on setup.py