### PR TITLE
ci: Make lint job name unique amongst workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,7 +1,7 @@
 name: Run lint
 on: [push, workflow_dispatch, pull_request]
 jobs:
-  tests:
+  pre-commit-lint:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository code


### PR DESCRIPTION
When using github merge queues one can configure which CI jobs need to run succesfully. Unfortunately that happens on the job name, so if they're not unique amongst all workflows it becomes ambigious...

Change the lint job name to be more unique