### PR TITLE
Test on different more modern Debian versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,36 @@ jobs:
       - name: Build container
         run: docker build -t pdudaemon-ci -f Dockerfile.dockerhub .
       - name: Run pytest
-        run: docker run -v $(pwd):/p -w /p pdudaemon-ci /root/.local/bin/pytest
+        run: docker run -v $(pwd):/p -w /p pdudaemon-ci /root/.local/pipx/venvs/pdudaemon/bin/pytest
+      - name: Run functional tests
+        run: docker run -v $(pwd):/p -w /p pdudaemon-ci sh -c "./share/pdudaemon-test.sh"
+  tests-trixie:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check out repository code
+        uses: actions/checkout@v4
+      - name: Build container
+        run: docker build --build-arg DEBIAN_VERSION=trixie -t pdudaemon-ci -f Dockerfile.dockerhub .
+      - name: Run pytest
+        run: docker run -v $(pwd):/p -w /p pdudaemon-ci /root/.local/share/pipx/venvs/pdudaemon/bin/pytest
+      - name: Run functional tests
+        run: docker run -v $(pwd):/p -w /p pdudaemon-ci sh -c "./share/pdudaemon-test.sh"
+  tests-trixie-python312:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check out repository code
+        uses: actions/checkout@v4
+      - name: Build container
+        run: >
+          docker build
+          --build-arg DEBIAN_VERSION=trixie
+          --build-arg PYTHON=python3.12
+          -t pdudaemon-ci -f Dockerfile.dockerhub
+          .
+      - name: Run pytest
+        run: docker run -v $(pwd):/p -w /p pdudaemon-ci /root/.local/share/pipx/venvs/pdudaemon/bin/pytest
+      - name:
+        # disable snmp as pysnmp is incompatible with python3.12
+        run: sed -i 's,"snmpv.","localcmdline",g' share/pdudaemon.conf
       - name: Run functional tests
         run: docker run -v $(pwd):/p -w /p pdudaemon-ci sh -c "./share/pdudaemon-test.sh"

--- a/Dockerfile.dockerhub
+++ b/Dockerfile.dockerhub
@@ -1,8 +1,13 @@
-FROM debian:bullseye
+ARG DEBIAN_VERSION=bookworm
+FROM debian:$DEBIAN_VERSION
 
 ARG HTTP_PROXY
 ENV http_proxy ${HTTP_PROXY}
 ENV https_proxy ${HTTP_PROXY}
+
+ARG PYTHON=python3
+ENV PIPX_BIN_DIR /usr/local/bin
+ENV PIPX_DEFAULT_PYTHON ${PYTHON}
 
 RUN apt-get update && apt-get install -y \
 curl \
@@ -16,7 +21,8 @@ libudev-dev \
 libusb-1.0-0-dev \
 pkg-config \
 psmisc \
-python3-pip \
+pipx \
+python3-pycodestyle \
 python3-setuptools \
 python3-usb \
 python3-wheel \
@@ -25,10 +31,11 @@ supervisor \
 telnet \
 snmp
 
+RUN apt-get update && apt-get install -y \
+  ${PYTHON}-venv ${PYTHON}-dev
+
 ADD share/pdudaemon.conf /config/
 WORKDIR /pdudaemon
 COPY . .
-RUN pip3 install --user pycodestyle==2.9.1
-RUN pip3 install .
-RUN pip3 install --user .[test]
+RUN pipx install .[test]
 CMD ["/usr/bin/supervisord", "-c", "/pdudaemon/share/supervisord.conf"]

--- a/pdudaemon/drivers/strategies.py
+++ b/pdudaemon/drivers/strategies.py
@@ -18,6 +18,8 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 #  MA 02110-1301, USA.
 
+import logging
+import os
 from pdudaemon.drivers.acme import ACME
 from pdudaemon.drivers.anelnetpwrctrl import AnelNETPwrCtrlHOME
 from pdudaemon.drivers.anelnetpwrctrl import AnelNETPwrCtrlADV
@@ -61,7 +63,6 @@ from pdudaemon.drivers.tasmota import BrennenstuhlWSPL01Tasmota
 from pdudaemon.drivers.egpms import EgPMS
 from pdudaemon.drivers.ykush import YkushXS
 from pdudaemon.drivers.ykush import Ykush
-from pdudaemon.drivers.snmp import SNMP
 from pdudaemon.drivers.energenieusb import EnerGenieUSB
 from pdudaemon.drivers.bcu import BCU
 from pdudaemon.drivers.vusbhid import VUSBHID
@@ -120,7 +121,6 @@ __all__ = [
     EgPMS.__name__,
     YkushXS.__name__,
     Ykush.__name__,
-    SNMP.__name__,
     EnerGenieUSB.__name__,
     BCU.__name__,
     VUSBHID.__name__,
@@ -135,3 +135,10 @@ __all__ = [
     Netio4.__name__,
     Cyberpower81001.__name__,
 ]
+
+log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
+try:
+    from pdudaemon.drivers.snmp import SNMP
+    __all__.append(SNMP.__name__)
+except ModuleNotFoundError:
+    log.warning("disabling snmp drivers due to missing modules")


### PR DESCRIPTION
Few diferent items here:
* Move the standard docker build to debian bookworm (current stable) from bullseye (previous stable)
* Also move the test container to pipx rather then pip as pip got unhappy with bookworm
* Add ability in the container to specify python and debian versions as build arguments
* Run tests for bookworm, trixie (*next* debian release) as well as trixie with python3.12
* Automatically ignore the snmp driver if it doesn't load (which happens on python 3.12 and newer)

Main goal is to fix https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1058396 which is keeping pdudaemon out of debian testing at the moment.