### PR TITLE
Use actions to publish packages to pypi

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,3 +48,57 @@ jobs:
         run: sed -i 's,"snmpv.","localcmdline",g' share/pdudaemon.conf
       - name: Run functional tests
         run: docker run -v $(pwd):/p -w /p pdudaemon-ci sh -c "./share/pdudaemon-test.sh"
+
+  build:
+    needs:
+      - tests
+      - tests-trixie
+      - tests-trixie-python312
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          # include tags and full history for setuptools_scm
+          fetch-depth: 0
+      - name: Install build deps
+        run: python -m pip install -U build
+      - name: Build package
+        run: python -m build
+      - name: Upload dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  pypi-publish-test:
+    if: ${{ github.event_name == 'push' && (startsWith(github.ref, 'refs/tags') || github.ref == 'refs/heads/master') }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish distribution package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  pypi-publish:
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
+    needs: pypi-publish-test
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish distribution package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This uses PyPI trusted publisher to manage upload permissions. Tags are uploaded as releases to normal PyPI, untagged commits are uploaded to TestPyPI.

An example run can be inspected at: https://github.com/pdudaemon/pdudaemon/actions/runs/8555306484