### PR TITLE
feat: add notifications for events

### DIFF
--- a/pdudaemon/tcplistener.py
+++ b/pdudaemon/tcplistener.py
@@ -64,8 +64,9 @@ class TCPListener:
             data = data.decode('utf-8')
             data = data.strip()
             try:
-                fut = loop.run_in_executor(None, socket.gethostbyaddr, request_ip)
-                request_host = (await asyncio.wait_for(fut, timeout=2))[0]
+                request_host = await asyncio.wait_for(
+                        loop.run_in_executor(None, socket.gethostbyaddr, request_ip),
+                        timeout=2)[0]
             except (socket.herror, asyncio.TimeoutError):
                 request_host = request_ip
             logger.info("Received a request from %s: '%s'", request_host, data)


### PR DESCRIPTION
Listener stores on/off events in a queue and notifies subscribers about new events by using long living HTTP requests.

This is something I need to keep my web front end up to date. Maybe someone else can make use of this feature as well.
I would be happy to discuss whether or not this should be part of `pdudaemon` and will gladly address any issues you might have with my code. Thanks!