### PR TITLE
Return False when a port doesn't change state

### DIFF
--- a/pdudaemon/listener.py
+++ b/pdudaemon/listener.py
@@ -99,11 +99,10 @@ async def process_request(args, config, daemon):
     runner = daemon.runners[args.hostname]
     if args.request == "reboot":
         logger.debug("reboot requested, submitting off/on")
-        await runner.do_job_async(args.port, "off")
+        if not await runner.do_job_async(args.port, "off"):
+            return False
         await asyncio.sleep(int(args.delay))
-        await runner.do_job_async(args.port, "on")
-        return True
+        return await runner.do_job_async(args.port, "on")
     else:
         await asyncio.sleep(int(args.delay))
-        await runner.do_job_async(args.port, args.request)
-        return True
+        return await runner.do_job_async(args.port, args.request)

--- a/pdudaemon/pdurunner.py
+++ b/pdudaemon/pdurunner.py
@@ -53,7 +53,8 @@ class PDURunner:
         retries = self.retries
         while retries > 0:
             try:
-                return self.driver.handle(request, port)
+                self.driver.handle(request, port)
+                return True
             except (OSError, pexpect.exceptions.EOF, Exception):  # pylint: disable=broad-except
                 self.logger.warn(traceback.format_exc())
                 self.logger.warn("Failed to execute job: {} {} (attempts left {})".format(port, request, retries - 1))


### PR DESCRIPTION
Currently all pdudaemon requests return a succeeded status even if
the underlying PDU request failed (e.g. the host wasn't able to
connect to the PDU due to hostname resolution). This can cause
callers to assume the every PDU request actually succeeded even though
it may have failed.

Rework process_request to return an error if the PDU fails (after
retries have exceeded) to change state. This allows users of pdudaemon
to error out early, when a PDU request fails, rather than assuming the
port changed state and continuing anyway. Currently this simply returns
with an error, stating that the port didn't change state but no detail
of what that error was.

Fixes: pdudaemon/pdudaemon#156