### PR TITLE
pyproject: limit pysnmp and pyasn1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ dependencies = [
     "paramiko",
     "pyserial",
     "hidapi",
-    "pysnmp",
-    "pyasn1",
+    "pysnmp>=4.4.12, <6",
+    "pyasn1<0.6.1",
     "pyusb",
     "pymodbus",
 ]


### PR DESCRIPTION
These are required since pdudaemon still uses the sync hlapi internally for some of the backends. To remedy this a new kind of backend implementation needs to be written which supports backends with async code. Then we need to port existing users over to the new async API.

Limit to versions which support the sync hlapi for now.