### PR TITLE
Enable tests workflow on tags

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches-ignore:
       - "gh-readonly-queue/**"
+    tags:
+      - "*"
   workflow_dispatch:
   pull_request:
   merge_group:


### PR DESCRIPTION
According to [1], tags are ignored if only branches/branches-ignore is given.

[1] https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore