### PR TITLE
Add support for alias groups

### DIFF
--- a/pdudaemon/listener.py
+++ b/pdudaemon/listener.py
@@ -27,6 +27,8 @@ class Args(object):
     alias = None
     request = None
     port = None
+    delay = None
+    group = None
     pass
 
 
@@ -58,13 +60,43 @@ def parse_http(data, path):
     # everything comes back from the http library in a 1 sized list
     args.alias = data.get('alias', [None])[0]
     args.hostname = data.get('hostname', [None])[0]
+    args.group = data.get('group', [None])[0]
     args.port = data.get('port', [None])[0]
     args.request = entry[2]
     args.delay = data.get('delay', [None])[0]
     return args
 
 
+async def process_group_request(args, config, daemon):
+    # A group fans a single request out to every alias tagged with that group
+    # name, so it is mutually exclusive with directly targeting a port.
+    if args.hostname or args.port or args.alias:
+        logger.error("Cannot combine a group request with a hostname, port or alias")
+        return False
+    aliases = config.get('aliases', {})
+    aliases_in_group = [
+        name for name, settings in aliases.items()
+        if settings.get('group') == args.group
+    ]
+    if not aliases_in_group:
+        logger.error("No aliases match the requested group: %s", args.group)
+        return False
+    # Attempt every member even if one fails, so a single unreachable PDU does
+    # not leave the rest of the group unactioned, then report failure if any
+    # member did not succeed.
+    results = []
+    for name in aliases_in_group:
+        member_args = Args()
+        member_args.request = args.request
+        member_args.delay = args.delay
+        member_args.alias = name
+        results.append(await process_request(member_args, config, daemon))
+    return all(results)
+
+
 async def process_request(args, config, daemon):
+    if args.group:
+        return await process_group_request(args, config, daemon)
     if args.request in ["on", "off"] and args.delay is not None:
         logger.warn("delay parameter is deprecated for on/off commands")
     if args.delay is not None:

--- a/share/expected_output.txt
+++ b/share/expected_output.txt
@@ -2,6 +2,10 @@ http 2 off
 http 2 on
 httpalias 1 off
 httpalias 1 on
+httpalias 1 off
+httpalias 1 on
+drivealias 2 off
+drivealias 2 on
 tcp 3 off
 tcp 3 on
 drive 4 off

--- a/share/pdudaemon-test.sh
+++ b/share/pdudaemon-test.sh
@@ -35,6 +35,10 @@ sleep 10
 curl -q "http://localhost:16421/power/control/reboot?alias=aliastesthttp01&delay=5" &> /dev/null
 sleep 10
 
+# Test alias group HTTP request
+curl -q "http://localhost:16421/power/control/reboot?group=testgroup&delay=1" &> /dev/null
+sleep 10
+
 kill $PDU_PID
 sleep 10
 

--- a/share/pdudaemon.conf
+++ b/share/pdudaemon.conf
@@ -173,11 +173,18 @@
     "aliases": {
         "aliastesthttp01": {
             "hostname": "httpalias",
-            "port": 1
+            "port": 1,
+            "group": "testgroup"
         },
         "aliastestdrive02": {
             "hostname": "drivealias",
-            "port": 2
+            "port": 2,
+            "group": "testgroup"
+        },
+        "aliastestother03": {
+            "hostname": "drivealias",
+            "port": 3,
+            "group": "othergroup"
         }
     }
 }


### PR DESCRIPTION
Add a new request argument of 'group'.
Allow port aliases to be requested as a group, allowing you to submit a request to multiple aliases at once.