### PR TITLE
feat: first steps towards reproducible builds

### DIFF
--- a/.github/workflows/dockerhub_latest.yaml
+++ b/.github/workflows/dockerhub_latest.yaml
@@ -1,6 +1,7 @@
-name: Publish Docker image
+---
+name: Publish latest Docker image
 
-on:
+"on":
   push:
     branches: ["main"]
 

--- a/.github/workflows/dockerhub_tags.yaml
+++ b/.github/workflows/dockerhub_tags.yaml
@@ -1,0 +1,29 @@
+---
+name: Publish version tagged Docker image
+
+"on":
+  push:
+    tags:
+      - '*'
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.dockerhub
+          push: true
+          tags: pdudaemon/pdudaemon:${{ github.ref_name }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "pysnmp>=4.4.12, <6",
     "pyasn1<0.6.1",
     "pyusb",
-    "pymodbus",
+    "pymodbus==3.7.4",
 ]
 dynamic = ["version"] # via setuptools_scm
 


### PR DESCRIPTION
These are the minimal changes needed to achieve the following two goals:

1. Automated Docker Image Tagging
  - In addition to the `latest` image tag, Docker images are now tagged using the same Git tag as the corresponding commit, ensuring consistency between Git releases and Docker tags.
  - This allows users to choose specific versions of pdudaemon. In case of errors, earlier images tags can be chosen from.
2. Pinning the pymodbus version
  - The pymodbus dependency has been explicitly pinned to version 3.7.4.
  - This decision addresses issues encountered with pymodbus 3.8.0, where communication with Modbus TCP couplers resulted in BROKEN PIPE errors.

The greater goal is to have reproducible builds by specifying versions of all used packages. This can be achieved using [uv](https://docs.astral.sh/uv/) but will potentially be done in future PRs.