### PR TITLE
Make TP-Link driver work with freshly installed device

### DIFF
--- a/pdudaemon/drivers/tplink.py
+++ b/pdudaemon/drivers/tplink.py
@@ -104,10 +104,12 @@ class TPLink(PDUDriver):
         context = None
         if command == "on":
             state = 1
-        if self.childinfo:
-            if int(port_number) > len(self.childinfo):
-                return (False)
-            context = self.get_context(port_number)
+        if not self.childinfo:
+            log.error(f"Device not yet initialised, can't send command")
+            return (False)
+        if int(port_number) > len(self.childinfo):
+            return (False)
+        context = self.get_context(port_number)
         datadict = {
             'context': context,
             'system': {


### PR DESCRIPTION
The TP-Link driver seems to depend on a user defined naming convention for plug/port naming. This doesn't seem to be documented anywhere and is unexpected. Tweak the driver so that it works with either a port index or whatever name is set for the devices ports.