### PR TITLE
README.md: The IRC channel is no more

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,5 +145,3 @@ pdudaemon.driver =
 
 ## Why can't PDUDaemon do $REQUIREMENT?
 Patches welcome, as long as it keeps the system simple and lightweight.
-## Contact
-#pdudaemon on Freenode


### PR DESCRIPTION
After the "staffing changes" at Freenode, the resulting exodus of projects from the platform and the relaunch, where no channels or users were migrated, it seems that the pdudaemon channel is no more.

I don't see a channel on Libra.Chat or OFTC, so delete the contact section from the README.