### PR TITLE
drivers: devantechusb: Extend driver for 4 and 6 relay units

### DIFF
--- a/pdudaemon/drivers/devantechusb.py
+++ b/pdudaemon/drivers/devantechusb.py
@@ -72,6 +72,18 @@ class DevantechUSB2(DevantechusbBase):
                  "devantech_USB-RLY82"]
 
 
+# 4 relay devices
+class DevantechUSB4(DevantechusbBase):
+    port_count = 4
+    supported = ["devantech_USB-RLY04"]
+
+
+# 6 relay devices
+class DevantechUSB6(DevantechusbBase):
+    port_count = 6
+    supported = ["devantech_USB-RLY06"]
+
+
 # Various 8 relay devices
 class DevantechUSB8(DevantechusbBase):
     port_count = 8


### PR DESCRIPTION
The USB-RLY04 and USB-RLY06 relay boards operate in the same way as the other existing boards from this family. Extend the driver to support these too.