### PR TITLE
pyproject: Add setuputils to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 ]
 requires-python = ">= 3.4"
 dependencies = [
+    "setuptools",
     "aiohttp",
     "requests",
     "pexpect",


### PR DESCRIPTION
pdudaemon imports pkg_resources at runtime to discover driver entry points. pkg_resources is provided by setuptools, but setuptools was only listed as a build dependency so it is not guaranteed to be present in runtime environments such as pipx venvs or minimal CI images.

Add setuptools to the project runtime dependencies to ensure pkg_resources is available when pdudaemon is executed.