### PR TITLE
Fix python 3.14 get_event_loop() error

### DIFF
--- a/pdudaemon/__init__.py
+++ b/pdudaemon/__init__.py
@@ -207,7 +207,7 @@ async def main_async():
 
 
 def main():
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     loop.run_until_complete(main_async())
     try:
         loop.run_forever()


### PR DESCRIPTION
Python 3.14 deprecates the get_event_loop() call for the default event loop policy, switch to new event loop since there is no use-case for passing an event loop.