### PR TITLE
Add ability to retrieve a port's powered state

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ An HTTP request URL has the following syntax:
       - **on**: power on
       - **off**: power off
       - **reboot**: reboot
+      - **get-port-state**: retrieve the powered state of the port (see the `Get port state` section below)
     - query-string can have 3 parameters (same as pduclient, see below)
       - **hostname**: the PDU hostname or IP address used in the [configuration file](https://github.com/pdudaemon/pdudaemon/blob/main/share/pdudaemon.conf) (e.g.: "192.168.10.2")
       - **port**: the PDU port number
@@ -132,7 +133,7 @@ Options:
   --hostname=PDUHOSTNAME
                         PDU Hostname (ex: pdu05)
   --port=PDUPORTNUM     PDU Portnumber (ex: 04)
-  --command=PDUCOMMAND  PDU command (ex: reboot|on|off)
+  --command=PDUCOMMAND  PDU command (ex: reboot|on|off|get-port-state)
   --delay=PDUDELAY      Delay before command runs, or between off/on when
                         rebooting (ex: 5)
 ```
@@ -146,6 +147,42 @@ $ pdudaemon --conf=share/pdudaemon.conf --drive --hostname pdu01 --port 1 --requ
 
 If requesting reboot, the delay between turning the port off and on can be modified with `--delay`
 and is by default 5 seconds.
+
+## Get port state
+pdudaemon can retrieve a port's powered state (on or off), if it is supported by the driver.
+Not all drivers implement status retrieval; unsupported drivers will return an error.
+
+- **HTTP**
+
+  Send a `GET` request to the `get-port-state` endpoint with the same `hostname` and `port` query parameters used for control commands:
+
+  ```
+  $ curl "http://localhost:16421/power/control/get-port-state?hostname=192.168.10.2&port=1"
+  {"state": "on"}
+  ```
+
+  The response body is a JSON object with a single `state` key:
+  - `on` - port is powered **on**
+  - `off` - port is powered **off**
+
+  HTTP 200 is returned when the state was read from the PDU. HTTP 500 is returned if the request is invalid or the driver does not support status retrieval.
+
+- **pduclient (TCP)**
+
+  Use `get-port-state` as the command. With the `--http` flag, the output is human-readable:
+
+  ```
+  $ pduclient --http --daemon localhost --hostname 192.168.10.2 --port 1 --command get-port-state
+  Port status: on
+  ```
+
+  Without `--http` (plain TCP), the raw daemon response (`on` or `off`) is printed.
+
+- **non-daemon (--drive)**
+
+  ```
+  $ pdudaemon --conf=share/pdudaemon.conf --drive --hostname pdu01 --port 1 --request get-port-state
+  ```
 
 ## Adding drivers
 Drivers are implemented children of the "PDUDriver" class and many example

--- a/pduclient
+++ b/pduclient
@@ -39,7 +39,10 @@ def do_tcp_request(options):
     except Exception:
         print ("Error sending command, wrong daemon hostname?")
         exit(1)
-    if reply == "ack":
+    if options.pducommand == "get-port-state":
+        print("Port state: %s" % reply)
+        exit(0)
+    elif reply == "ack":
         print("Command sent successfully.")
         exit(0)
     else:
@@ -61,7 +64,11 @@ def do_http_request(options):
         print ("Error sending command, wrong daemon hostname?")
         exit(1)
     if reply.ok:
-        print("Command sent successfully.")
+        if options.pducommand == "get-port-state":
+            data = reply.json()
+            print("Port state: %s" % data.get("state"))
+        else:
+            print("Command sent successfully.")
         exit(0)
     else:
         print("Error sending command! %s replied: %s" %
@@ -73,7 +80,7 @@ if __name__ == '__main__':
     usage = "Usage: %prog --daemon deamonhostname --hostname pduhostname " \
             "--port pduportnum --command pducommand"
     description = "PDUDaemon client"
-    commands = ["reboot", "on", "off"]
+    commands = ["reboot", "on", "off", "get-port-state"]
     parser = optparse.OptionParser(usage=usage, description=description)
     parser.add_option("-H", "--http", dest="use_http", action="store_true",
                       help="Use HTTP protocol")
@@ -85,7 +92,7 @@ if __name__ == '__main__':
     parser.add_option("--port", dest="pduportnum", action="store",
                       type="string", help="PDU Portnumber (ex: 04)")
     parser.add_option("--command", dest="pducommand", action="store",
-                      type="string", help="PDU command (ex: reboot|on|off)")
+                      type="string", help="PDU command (ex: reboot|on|off|get-port-state)")
     parser.add_option("--delay", dest="pdudelay", action="store", type="int",
                       help="Delay before command runs, or between off/on "
                            "when rebooting (ex: 5)")

--- a/pdudaemon/__init__.py
+++ b/pdudaemon/__init__.py
@@ -191,6 +191,9 @@ async def main_async():
                 await runner.port_on_async(options.driveport)
             elif options.driverequest == "off":
                 await runner.port_off_async(options.driveport)
+            elif options.driverequest == "get-port-state":
+                result = await runner.get_port_state_async(options.driveport)
+                logger.info("Port %s state: %s", options.driveport, "on" if result else "off")
             else:
                 logger.error("Unknown request: %s", options.driverequest)
                 result = False

--- a/pdudaemon/__init__.py
+++ b/pdudaemon/__init__.py
@@ -181,12 +181,22 @@ async def main_async():
             sys.exit(1)
 
         runner = PDURunner(config, options.drivehostname, options.driveretries, options.driveretrydelay)
-        if options.driverequest == "reboot":
-            result = await runner.do_job_async(options.driveport, "off")
-            await asyncio.sleep(int(options.drivedelay))
-            result = await runner.do_job_async(options.driveport, "on")
-        else:
-            result = await runner.do_job_async(options.driveport, options.driverequest)
+        result = True
+        try:
+            if options.driverequest == "reboot":
+                await runner.port_off_async(options.driveport)
+                await asyncio.sleep(int(options.drivedelay))
+                await runner.port_on_async(options.driveport)
+            elif options.driverequest == "on":
+                await runner.port_on_async(options.driveport)
+            elif options.driverequest == "off":
+                await runner.port_off_async(options.driveport)
+            else:
+                logger.error("Unknown request: %s", options.driverequest)
+                result = False
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error("Request failed: %s", exc)
+            result = False
         await runner.shutdown()
         loop.stop()
         return result

--- a/pdudaemon/drivers/devantechusb.py
+++ b/pdudaemon/drivers/devantechusb.py
@@ -61,6 +61,20 @@ class DevantechusbBase(PDUDriver):
         s.write([byte])
         s.close()
 
+    def get_port_state(self, port_number) -> bool:
+        port_number = int(port_number)
+        if port_number > self.port_count or port_number < 1:
+            err = "Port should be in the range 1 - %d" % (self.port_count)
+            log.error(err)
+            raise RuntimeError(err)
+
+        s = serial.serial_for_url(self.device, 9600)
+        s.write([0x5B])
+        relay_states = ord(s.read(1))
+        s.close()
+
+        return bool(relay_states & (1 << (port_number - 1)))
+
     @classmethod
     def accepts(cls, drivername):
         return drivername in cls.supported

--- a/pdudaemon/drivers/driver.py
+++ b/pdudaemon/drivers/driver.py
@@ -64,21 +64,6 @@ class PDUDriver(object):
         log.debug("%s accepted the request", willing[0])
         return willing[0]
 
-    def handle(self, request, port_number):
-        log.debug("Driving PDU hostname: %s "
-                  "PORT: %s REQUEST: %s",
-                  self.hostname, port_number, request)
-        if request == "on":
-            self.port_on(port_number)
-        elif request == "off":
-            self.port_off(port_number)
-        else:
-            log.debug("Unknown request to handle - oops")
-            raise UnknownCommandException(
-                "Driver doesn't know how to %s " % request
-            )
-        self._cleanup()
-
     def port_on(self, port_number):
         self.port_interaction("on", port_number)
 

--- a/pdudaemon/drivers/driver.py
+++ b/pdudaemon/drivers/driver.py
@@ -70,6 +70,13 @@ class PDUDriver(object):
     def port_off(self, port_number):
         self.port_interaction("off", port_number)
 
+    def get_port_state(self, port_number) -> bool:
+        """Return True if the port is powered on, False if powered off. Raises
+        UnknownCommandException if retrieving the port status is unsupported by
+        the driver.
+        """
+        raise UnknownCommandException("Driver doesn't support get-port-state")
+
     def port_interaction(self, command, port_number):
         pass
 

--- a/pdudaemon/drivers/esphome.py
+++ b/pdudaemon/drivers/esphome.py
@@ -72,6 +72,25 @@ class ESPHomeHTTP(PDUDriver):
         )
         response.raise_for_status()
 
+    def get_port_state(self, esphome_entity_id) -> bool:
+        url = "http://{}:{}/switch/{}".format(self.hostname, self.port, esphome_entity_id)
+        log.debug("HTTP GET: {}".format(url))
+
+        auth = None
+        if self.username and self.password:
+            auth = HTTPDigestAuth(self.username, self.password)
+
+        response = requests.get(url, auth=auth)
+        response.raise_for_status()
+        data = response.json()
+
+        log.debug(
+            "Response for request to {}: code: {}, data: {}".format(
+                self.hostname, response.status_code, data
+            )
+        )
+        return data.get("state") == "ON"
+
     @classmethod
     def accepts(cls, drivername):
         return drivername == "esphome-http"

--- a/pdudaemon/drivers/homeassistant.py
+++ b/pdudaemon/drivers/homeassistant.py
@@ -69,6 +69,25 @@ class HomeAssistantHTTP(PDUDriver):
         )
         response.raise_for_status()
 
+    def get_port_state(self, ha_entity_id) -> bool:
+        url = "http://{}:{}/api/states/switch.{}".format(
+            self.hostname, self.port, ha_entity_id
+        )
+        log.debug("HTTP GET: {}".format(url))
+
+        headers = {"Authorization": "Bearer {}".format(self.api_key)}
+
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+
+        log.debug(
+            "Response for request to {}: code: {}, data: {}".format(
+                self.hostname, response.status_code, data
+            )
+        )
+        return data.get("state") == "on"
+
     @classmethod
     def accepts(cls, drivername):
         return drivername == "home-assistant-http"

--- a/pdudaemon/drivers/uhubctl.py
+++ b/pdudaemon/drivers/uhubctl.py
@@ -21,7 +21,7 @@
 import logging
 import os
 from shutil import which
-from subprocess import check_call
+from subprocess import check_call, check_output
 from pdudaemon.drivers.localbase import LocalBase
 
 log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
@@ -76,3 +76,24 @@ class UHubCtl(LocalBase):
         ]
         log.debug("running %r" % cmd)
         check_call(cmd)
+
+    def get_port_state(self, port_number) -> bool:
+        try:
+            port_number = int(port_number)
+        except (TypeError, ValueError):
+            raise RuntimeError("port_number must be an integer, got %r" % (port_number,))
+
+        # Run uhubctl to retrieve the port status
+        cmd = [
+            self.uhubctl_bin,
+            "--location", str(self.location),
+            "--port", str(port_number),
+        ]
+        log.debug("running %r" % cmd)
+        output = check_output(cmd, text=True)
+
+        prefix = "  Port %s:" % port_number
+        for line in output.splitlines():
+            if line.startswith(prefix):
+                return " power" in line
+        raise RuntimeError("uhubctl did not report status for port %s" % port_number)

--- a/pdudaemon/httplistener.py
+++ b/pdudaemon/httplistener.py
@@ -38,6 +38,7 @@ class HTTPListener:
             web.get('/power/control/on', self.handle),
             web.get('/power/control/off', self.handle),
             web.get('/power/control/reboot', self.handle),
+            web.get('/power/control/get-port-state', self.handle),
         ])
         self.apprunner = None
 
@@ -61,6 +62,9 @@ class HTTPListener:
         data = urlparse.parse_qs(urlparse.urlparse(request.path_qs).query)
         path = urlparse.urlparse(request.path_qs).path
         res = await self.insert_request(data, path)
+        if isinstance(res, listener.PortStatus):
+            return web.Response(status=200, content_type="application/json",
+                                text='{"state": "%s"}\n' % ("on" if res.on else "off"))
         if isinstance(res, listener.CommandAccepted):
             return web.Response(status=200, text="OK - accepted request\n")
         if isinstance(res, listener.RequestError):

--- a/pdudaemon/httplistener.py
+++ b/pdudaemon/httplistener.py
@@ -61,12 +61,14 @@ class HTTPListener:
         data = urlparse.parse_qs(urlparse.urlparse(request.path_qs).query)
         path = urlparse.urlparse(request.path_qs).path
         res = await self.insert_request(data, path)
-        if res:
+        if isinstance(res, listener.CommandAccepted):
             return web.Response(status=200, text="OK - accepted request\n")
-        else:
-            return web.Response(status=500, text="Invalid request\n")
+        if isinstance(res, listener.RequestError):
+            return web.Response(status=500, text="Invalid request: %s\n" % res.message)
+        return web.Response(status=500, text="Invalid request\n")
 
     async def insert_request(self, data, path):
         args = listener.parse_http(data, path)
-        if args:
-            return await listener.process_request(args, self.config, self.daemon)
+        if not args:
+            return listener.RequestError("could not parse request")
+        return await listener.process_request(args, self.config, self.daemon)

--- a/pdudaemon/listener.py
+++ b/pdudaemon/listener.py
@@ -19,7 +19,26 @@
 
 import asyncio
 import logging
+from dataclasses import dataclass
+
 logger = logging.getLogger('pdud.listener')
+
+
+class RequestResult:
+    """Base class for typed results returned by process_request."""
+    pass
+
+
+@dataclass
+class CommandAccepted(RequestResult):
+    """A set-style command (on/off/reboot) was successfully accepted."""
+    pass
+
+
+@dataclass
+class RequestError(RequestResult):
+    """The request was rejected or failed."""
+    message: str
 
 
 class Args(object):
@@ -64,7 +83,10 @@ def parse_http(data, path):
     return args
 
 
-async def process_request(args, config, daemon):
+def _resolve_args(args, config):
+    """Validate args and resolve any alias. Returns a RequestError on failure,
+    or None on success (mutating args in place).
+    """
     if args.request in ["on", "off"] and args.delay is not None:
         logger.warn("delay parameter is deprecated for on/off commands")
     if args.delay is not None:
@@ -79,30 +101,43 @@ async def process_request(args, config, daemon):
     if args.alias:
         if args.hostname or args.port:
             logger.error("Trying to use and alias and also a hostname/port")
-            return False
-        # Using alias support, get all pdu info from alias
+            return RequestError("alias cannot be combined with hostname/port")
         alias_settings = (config.get('aliases', {})).get(args.alias, False)
         if not alias_settings:
             logger.error("Alias requested but not found")
-            return False
+            return RequestError("alias not found")
         args.hostname = config["aliases"][args.alias]["hostname"]
         args.port = config["aliases"][args.alias]["port"]
     if not args.hostname or not args.port or not args.request:
         logger.info("One of hostname,port,request was not set")
-        return False
+        return RequestError("hostname, port or request was not set")
     if args.hostname not in config['pdus']:
         logger.info("PDU was not found in config")
-        return False
+        return RequestError("PDU not found in config")
     if args.request not in ["reboot", "on", "off"]:
         logger.info("Unknown request: %s", args.request)
-        return False
+        return RequestError("unknown request: %s" % args.request)
+    return None
+
+
+async def process_request(args, config, daemon) -> RequestResult:
+    err = _resolve_args(args, config)
+    if err is not None:
+        return err
     runner = daemon.runners[args.hostname]
-    if args.request == "reboot":
-        logger.debug("reboot requested, submitting off/on")
-        if not await runner.do_job_async(args.port, "off"):
-            return False
+    try:
+        if args.request == "reboot":
+            logger.debug("reboot requested, submitting off/on")
+            await runner.port_off_async(args.port)
+            await asyncio.sleep(int(args.delay))
+            await runner.port_on_async(args.port)
+            return CommandAccepted()
         await asyncio.sleep(int(args.delay))
-        return await runner.do_job_async(args.port, "on")
-    else:
-        await asyncio.sleep(int(args.delay))
-        return await runner.do_job_async(args.port, args.request)
+        if args.request == "on":
+            await runner.port_on_async(args.port)
+        else:  # "off"
+            await runner.port_off_async(args.port)
+        return CommandAccepted()
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.warn("Request failed: %s", exc)
+        return RequestError(str(exc))

--- a/pdudaemon/listener.py
+++ b/pdudaemon/listener.py
@@ -36,6 +36,12 @@ class CommandAccepted(RequestResult):
 
 
 @dataclass
+class PortStatus(RequestResult):
+    """Result of a get-port-state request - True if the port is powered on."""
+    on: bool
+
+
+@dataclass
 class RequestError(RequestResult):
     """The request was rejected or failed."""
     message: str
@@ -114,7 +120,7 @@ def _resolve_args(args, config):
     if args.hostname not in config['pdus']:
         logger.info("PDU was not found in config")
         return RequestError("PDU not found in config")
-    if args.request not in ["reboot", "on", "off"]:
+    if args.request not in ["reboot", "on", "off", "get-port-state"]:
         logger.info("Unknown request: %s", args.request)
         return RequestError("unknown request: %s" % args.request)
     return None
@@ -132,6 +138,9 @@ async def process_request(args, config, daemon) -> RequestResult:
             await asyncio.sleep(int(args.delay))
             await runner.port_on_async(args.port)
             return CommandAccepted()
+        if args.request == "get-port-state":
+            on = await runner.get_port_state_async(args.port)
+            return PortStatus(on=on)
         await asyncio.sleep(int(args.delay))
         if args.request == "on":
             await runner.port_on_async(args.port)

--- a/pdudaemon/pdurunner.py
+++ b/pdudaemon/pdurunner.py
@@ -24,7 +24,7 @@ import time
 import traceback
 import pexpect
 import concurrent.futures
-from pdudaemon.drivers.driver import PDUDriver
+from pdudaemon.drivers.driver import FailedRequestException, PDUDriver
 import pdudaemon.drivers.strategies
 
 assert pdudaemon.drivers.strategies, "Subclasses are iterated to find all drivers"
@@ -49,13 +49,14 @@ class PDURunner:
         driver = PDUDriver.select(drivername)(hostname, self.config)
         return driver
 
-    def do_job(self, port, request):
+    def _run_with_retries(self, port, request, action):
         self.logger.info("Processing job for PDU %s: (%s %s)", self.hostname, request, port)
         retries = self.retries
         while retries > 0:
             try:
-                self.driver.handle(request, port)
-                return True
+                result = action()
+                self.driver._cleanup()  # pylint: disable=W0212
+                return result
             except (OSError, pexpect.exceptions.EOF, Exception):  # pylint: disable=broad-except
                 self.logger.warn(traceback.format_exc())
                 self.logger.warn("Failed to execute job: {} {} (attempts left {})".format(port, request, retries - 1))
@@ -64,8 +65,22 @@ class PDURunner:
                 time.sleep(self.retrydelay)
                 retries -= 1
                 continue
-        return False
+        raise FailedRequestException(
+            "Failed to {} port {} on PDU {} after {} retries".format(request, port, self.hostname, self.retries)
+        )
 
-    async def do_job_async(self, port, request):
+    def port_on(self, port):
+        self._run_with_retries(port, "on", lambda: self.driver.port_on(port))
+
+    def port_off(self, port):
+        self._run_with_retries(port, "off", lambda: self.driver.port_off(port))
+
+    async def _in_executor(self, fn, *args):
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(self.executor, self.do_job, port, request)
+        return await loop.run_in_executor(self.executor, fn, *args)
+
+    async def port_on_async(self, port) -> None:
+        await self._in_executor(self.port_on, port)
+
+    async def port_off_async(self, port) -> None:
+        await self._in_executor(self.port_off, port)

--- a/pdudaemon/pdurunner.py
+++ b/pdudaemon/pdurunner.py
@@ -75,6 +75,9 @@ class PDURunner:
     def port_off(self, port):
         self._run_with_retries(port, "off", lambda: self.driver.port_off(port))
 
+    def get_port_state(self, port) -> bool:
+        return self._run_with_retries(port, "get-port-state", lambda: self.driver.get_port_state(port))
+
     async def _in_executor(self, fn, *args):
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(self.executor, fn, *args)
@@ -84,3 +87,6 @@ class PDURunner:
 
     async def port_off_async(self, port) -> None:
         await self._in_executor(self.port_off, port)
+
+    async def get_port_state_async(self, port) -> bool:
+        return await self._in_executor(self.get_port_state, port)

--- a/pdudaemon/tcplistener.py
+++ b/pdudaemon/tcplistener.py
@@ -53,8 +53,9 @@ class TCPListener:
 
     async def insert_request(self, data):
         args = listener.parse_tcp(data)
-        if args:
-            return await listener.process_request(args, self.config, self.daemon)
+        if not args:
+            return listener.RequestError("could not parse request")
+        return await listener.process_request(args, self.config, self.daemon)
 
     async def handle(self, reader, writer):
         request_ip = writer.get_extra_info('peername')[0]
@@ -70,7 +71,7 @@ class TCPListener:
                 request_host = request_ip
             logger.info("Received a request from %s: '%s'", request_host, data)
             res = await self.insert_request(data)
-            if res:
+            if isinstance(res, listener.CommandAccepted):
                 writer.write("ack\n".encode('utf-8'))
             else:
                 writer.write("nack\n".encode('utf-8'))

--- a/pdudaemon/tcplistener.py
+++ b/pdudaemon/tcplistener.py
@@ -71,7 +71,9 @@ class TCPListener:
                 request_host = request_ip
             logger.info("Received a request from %s: '%s'", request_host, data)
             res = await self.insert_request(data)
-            if isinstance(res, listener.CommandAccepted):
+            if isinstance(res, listener.PortStatus):
+                writer.write(("on\n" if res.on else "off\n").encode('utf-8'))
+            elif isinstance(res, listener.CommandAccepted):
                 writer.write("ack\n".encode('utf-8'))
             else:
                 writer.write("nack\n".encode('utf-8'))


### PR DESCRIPTION
Add a new `get-status` command to pdudaemon that retrieves the current powered state (on or off) of a PDU port.

Previously, pdudaemon was write-only: you could turn ports on/off but it had no way to query a port's current state. This change adds that capability for drivers that support it, with the Home Assistant, ESPHome, Devantech USB and UHubCtl drivers as the first implementations.


Fixes: #97