### PR TITLE
Add uhubctl driver for USB hub port power control

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ python3-wheel \
 rustc \
 supervisor \
 telnet \
-snmp
+snmp \
+uhubctl
 
 RUN apt-get update && apt-get install -y \
   ${PYTHON}-venv ${PYTHON}-dev

--- a/pdudaemon/drivers/strategies.py
+++ b/pdudaemon/drivers/strategies.py
@@ -81,6 +81,7 @@ from pdudaemon.drivers.cyberpower81001 import Cyberpower81001
 from pdudaemon.drivers.homeassistant import HomeAssistantHTTP
 from pdudaemon.drivers.ubus import Ubus
 from pdudaemon.drivers.shelly_gen2 import ShellyGen2
+from pdudaemon.drivers.uhubctl import UHubCtl
 
 __all__ = [
     ACME.__name__,
@@ -144,6 +145,7 @@ __all__ = [
     HomeAssistantHTTP.__name__,
     Ubus.__name__,
     ShellyGen2.__name__,
+    UHubCtl.__name__,
 ]
 
 log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))

--- a/pdudaemon/drivers/uhubctl.py
+++ b/pdudaemon/drivers/uhubctl.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python3
+
+#  Copyright 2026 Linaro Limited
+#  Author Christopher Obbard <christopher.obbard@linaro.org>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+
+import logging
+import os
+from shutil import which
+from subprocess import check_call
+from pdudaemon.drivers.localbase import LocalBase
+
+log = logging.getLogger("pdud.drivers." + os.path.basename(__file__))
+
+
+class UHubCtl(LocalBase):
+
+    def __init__(self, hostname, settings):
+        self.hostname = hostname
+        self.settings = settings
+        self.location = settings.get("location", None)
+        if not self.location:
+            raise RuntimeError("uhubctl driver requires a 'location' setting")
+
+        # Find uhubctl binary
+        search_path = os.pathsep.join([
+            os.environ.get("PATH", ""),
+            "/sbin",
+            "/usr/sbin",
+            "/usr/local/sbin",
+        ])
+        self.uhubctl_bin = which("uhubctl", path=search_path)
+        if self.uhubctl_bin is None:
+            raise RuntimeError("uhubctl not found in PATH, /sbin, /usr/sbin or /usr/local/sbin")
+
+    @classmethod
+    def accepts(cls, drivername):
+        if drivername == "uhubctl":
+            return True
+        return False
+
+    def _port_interaction(self, command, port_number):
+        if command == "on":
+            action = "on"
+        elif command == "off":
+            action = "off"
+        else:
+            log.debug("Unknown command!")
+            return
+
+        # Run uhubctl to control the port power
+        cmd = [
+            self.uhubctl_bin,
+            "--location", str(self.location),
+            "--port", str(port_number),
+            "--action", str(action)
+        ]
+        log.debug("running %r" % cmd)
+        check_call(cmd)

--- a/share/pdudaemon.conf
+++ b/share/pdudaemon.conf
@@ -164,6 +164,10 @@
             "port_count": 4,
             "username": "user",
             "password": "password"
+        },
+        "UsbHub": {
+            "driver": "uhubctl",
+            "location": "1-2.4.4"
         }
     },
     "aliases": {


### PR DESCRIPTION
Add a new driver to wrap the uhubctl utility to enable/disable power to individual ports of (supported!) USB hubs. The driver is configured with a hub location (e.g. `1-2.4.4`) and uses the port number from the request to invoke uhubctl to control the power to the port.