### PR TITLE
drivers: uhubctl: check port_number is integer

### DIFF
--- a/pdudaemon/drivers/uhubctl.py
+++ b/pdudaemon/drivers/uhubctl.py
@@ -54,6 +54,11 @@ class UHubCtl(LocalBase):
         return False
 
     def _port_interaction(self, command, port_number):
+        try:
+            port_number = int(port_number)
+        except (TypeError, ValueError):
+            raise RuntimeError("port_number must be an integer, got %r" % (port_number,))
+
         if command == "on":
             action = "on"
         elif command == "off":


### PR DESCRIPTION
_port_interaction passed port_number straight into the uhubctl arguments via str(). Since the value originates from user input, a non-numeric string could be smuggled in as a uhubctl argument and potentially inject shell commands. Check port_number is an integer early to prevent command injection.